### PR TITLE
Update ratings and reviews only for completed items

### DIFF
--- a/src/core/sync/base.py
+++ b/src/core/sync/base.py
@@ -417,12 +417,6 @@ class BaseSyncClient(ABC, Generic[T, S]):
                 anilist_media=anilist_media,
                 animapping=animapping,
             ),
-            score=self._calculate_score(
-                item=item,
-                subitem=subitem,
-                anilist_media=anilist_media,
-                animapping=animapping,
-            ),
             progress=self._calculate_progress(
                 item=item,
                 subitem=subitem,
@@ -440,18 +434,14 @@ class BaseSyncClient(ABC, Generic[T, S]):
         if media_list.status is None:
             return media_list
 
-        if "notes" not in self.excluded_sync_fields:
-            media_list.notes = self.plex_client.get_user_review(
-                subitem
-            ) or self.plex_client.get_user_review(item)
-
-        if media_list.status > MediaListStatus.PLANNING:
+        if media_list.status >= MediaListStatus.CURRENT:
             media_list.started_at = self._calculate_started_at(
                 item=item,
                 subitem=subitem,
                 anilist_media=anilist_media,
                 animapping=animapping,
             )
+
         if media_list.status >= MediaListStatus.COMPLETED:
             media_list.completed_at = self._calculate_completed_at(
                 item=item,
@@ -459,6 +449,18 @@ class BaseSyncClient(ABC, Generic[T, S]):
                 anilist_media=anilist_media,
                 animapping=animapping,
             )
+
+            media_list.score = self._calculate_score(
+                item=item,
+                subitem=subitem,
+                anilist_media=anilist_media,
+                animapping=animapping,
+            )
+
+            if "notes" not in self.excluded_sync_fields:  # Avoid unnecessary API calls
+                media_list.notes = self.plex_client.get_user_review(
+                    subitem
+                ) or self.plex_client.get_user_review(item)
 
         return media_list
 


### PR DESCRIPTION
### Description

Ratings and reviews were being updated for media that weren't completely watched. This was especially an issue for reviews of shows because they fall back to the show's review if the there was no season review, so it's hard to tell if the review was meant for that specific season.

<!-- Remove any of the following sections if they are not used -->

**Fixes:**

- Ratings and reviews being updated for incomplete series