### PR TITLE
Fix cache polling conflict

### DIFF
--- a/src/core/anilist.py
+++ b/src/core/anilist.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from functools import cache
+from functools import lru_cache
 from pathlib import Path
 from textwrap import dedent
 from time import sleep
@@ -198,7 +198,7 @@ class AniListClient:
             or not episodes
         ]
 
-    @cache
+    @lru_cache(maxsize=None)
     def _search_anime(
         self,
         search_str: str,

--- a/src/core/bridge.py
+++ b/src/core/bridge.py
@@ -191,7 +191,7 @@ class BridgeClient:
             self._set_last_config_encoded(self.config.encode())
 
         log.info(
-            f"{self.__class__.__name__}: {'polling' if poll else 'periodic'} sync completed"
+            f"{self.__class__.__name__}: {'Polling' if poll else 'Periodic'} sync completed"
         )
 
     def _sync_user(self, anilist_token: str, plex_user: str, poll: bool) -> None:

--- a/src/core/bridge.py
+++ b/src/core/bridge.py
@@ -57,6 +57,8 @@ class BridgeClient:
         the database is properly connected and ready for use.
         """
         self.animap_client.reinit()
+        for plex_client in self.plex_clients.values():
+            plex_client.clear_cache()
 
     def _get_last_synced(self) -> datetime | None:
         """Retrieves the timestamp of the last successful sync from the database.

--- a/src/core/plex.py
+++ b/src/core/plex.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from functools import cache
+from functools import lru_cache
 from textwrap import dedent
 
 import plexapi.utils
@@ -44,6 +44,14 @@ class PlexClient:
         self.admin_client = PlexServer(plex_url, plex_token)
         self._init_user_client()
         self.on_deck_window = self._get_on_deck_window()
+
+    def clear_cache(self) -> None:
+        """Clears the cache for all decorated methods in the class."""
+        for attr in dir(self):
+            if callable(getattr(self, attr)) and hasattr(
+                getattr(self, attr), "cache_clear"
+            ):
+                getattr(self, attr).cache_clear()
 
     def _init_user_client(self) -> PlexServer:
         """Initializes the Plex client for the specified user account.
@@ -165,7 +173,7 @@ class PlexClient:
 
         return section.search(filters=filters)
 
-    @cache
+    @lru_cache
     def get_user_review(self, item: Movie | Show | Season) -> str | None:
         """Retrieves user review for a media item from Plex community.
 
@@ -328,7 +336,7 @@ class PlexClient:
             )
         return []
 
-    @cache
+    @lru_cache
     def get_history(
         self,
         item: Movie | Show | Season | Episode,

--- a/src/core/sync/base.py
+++ b/src/core/sync/base.py
@@ -163,6 +163,14 @@ class BaseSyncClient(ABC, Generic[T, S]):
 
         self.sync_stats = SyncStats()
 
+    def clear_cache(self) -> None:
+        """Clears the cache for all decorated methods in the class."""
+        for attr in dir(self):
+            if callable(getattr(self, attr)) and hasattr(
+                getattr(self, attr), "cache_clear"
+            ):
+                getattr(self, attr).cache_clear()
+
     def process_media(self, item: T) -> SyncStats:
         """Processes a single media item for synchronization.
 

--- a/src/core/sync/show.py
+++ b/src/core/sync/show.py
@@ -1,6 +1,6 @@
 import sys
 from datetime import datetime
-from functools import cache
+from functools import lru_cache
 from typing import Iterator
 
 import plexapi.exceptions
@@ -288,7 +288,7 @@ class ShowSyncClient(BaseSyncClient[Show, Season]):
             FuzzyDate.from_date(episode.lastViewedAt),
         )
 
-    @cache
+    @lru_cache
     def __filter_mapped_episodes(
         self, item: Show, subitem: Season, anilist_media: Media, animapping: AniMap
     ) -> list[Episode]:


### PR DESCRIPTION
### Description

With the new polling capabilities introduced in #60, not cleaning up the cache now matters. Previously, the program's objects would be reinitialized every run. With polling, this was inefficient, so the same object was kept. This means the cache stuck around, which caused data to not update.

**Fixes:**

- Polling scan and cache conflict

### Issues Fixed or Closed by this PR

- Closes #61 
