### PR TITLE
Custom mapping type validation error fix

### DIFF
--- a/src/core/animap.py
+++ b/src/core/animap.py
@@ -122,6 +122,16 @@ class AniMapClient:
                     for anilist_id_str, data in custom_data.items():
                         if anilist_id_str.startswith("$"):
                             continue
+
+                        for attr in (
+                            "mal_id",
+                            "imdb_id",
+                            "tmdb_movie_id",
+                            "tmdb_show_id",
+                        ):
+                            if attr in data:
+                                data[attr] = single_val_to_list(data[attr])
+
                         try:
                             AniMap.model_validate(
                                 {


### PR DESCRIPTION
### Description

The schema for the custom mappings allows for the values to be either a list or a single value. However, if the user provides just a single value, PlexAniBridge would log a warning with a validation error and skip that custom mapping. This PR allows for single value fields.

**What's new:**

**Improvements:**

**Fixes:**

- Custom mapping type validation error fix

### Issues Fixed or Closed by this PR

- #65 
