### PR TITLE
Response caching optimizations

### DIFF
--- a/src/core/anilist.py
+++ b/src/core/anilist.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
-from functools import lru_cache
 from pathlib import Path
 from textwrap import dedent
 from time import sleep
 
 import requests
+from cachetools.func import lru_cache, ttl_cache
 
 from src import log
 from src.models.anilist import (
@@ -160,6 +160,7 @@ class AniListClient:
 
         return response["deleted"]
 
+    @ttl_cache(maxsize=None, ttl=86400)
     def search_anime(
         self,
         search_str: str,

--- a/src/core/plex.py
+++ b/src/core/plex.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timedelta
-from functools import lru_cache
 from textwrap import dedent
 
 import plexapi.utils
 import requests
+from cachetools.func import lru_cache
 from plexapi.library import MovieSection, ShowSection
 from plexapi.server import PlexServer
 from plexapi.video import Episode, EpisodeHistory, Movie, MovieHistory, Season, Show
@@ -173,7 +173,7 @@ class PlexClient:
 
         return section.search(filters=filters)
 
-    @lru_cache
+    @lru_cache(maxsize=32)
     def get_user_review(self, item: Movie | Show | Season) -> str | None:
         """Retrieves user review for a media item from Plex community.
 
@@ -336,7 +336,7 @@ class PlexClient:
             )
         return []
 
-    @lru_cache
+    @lru_cache(maxsize=32)
     def get_history(
         self,
         item: Movie | Show | Season | Episode,

--- a/src/core/sync/show.py
+++ b/src/core/sync/show.py
@@ -1,9 +1,9 @@
 import sys
 from datetime import datetime
-from functools import lru_cache
 from typing import Iterator
 
 import plexapi.exceptions
+from cachetools.func import lru_cache
 from plexapi.video import Episode, Season, Show
 
 from src.models.anilist import FuzzyDate, Media, MediaListStatus
@@ -288,7 +288,7 @@ class ShowSyncClient(BaseSyncClient[Show, Season]):
             FuzzyDate.from_date(episode.lastViewedAt),
         )
 
-    @lru_cache
+    @lru_cache(maxsize=32)
     def __filter_mapped_episodes(
         self, item: Show, subitem: Season, anilist_media: Media, animapping: AniMap
     ) -> list[Episode]:


### PR DESCRIPTION
### Description

AniList search response caching was removed in #62. This PR adds it back in a way that's compatible with the polling scanner. AniList search responses will expire with a time-to-live of 1 day now.

This PR also includes caching optimizations for Plex responses. The cache size is now a smaller, more reasonable size.

**Improvements:**

- Caching optimizations