### PR TITLE
Seperate periodic and polling syncs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,9 +89,7 @@ Interval in seconds between sync jobs. Set to `-1` to run once and exit.
 
 ??? note "Sync Interval with Polling Scan"
 
-    If `POLLING_SCAN` is enabled, the sync interval still applies. The polling scanner will run in addition to the regular sync.
-
-    The difference being that the polling scanner will only sync the changes detected in the library, while the regular sync will pull the mappings database and sync the entire library.
+    If `POLLING_SCAN` is enabled, the sync interval will be used to determine how often to synchronize the [mappings database](./advanced/custom-mappings.md) and your AniList profile. Periodic scans will be disabled (unless it is your first run).
 
 ### `POLLING_SCAN`
 
@@ -101,9 +99,9 @@ When enabled, PlexAniBridge will poll the Plex server for changes instead of wai
 
 The polling scanner is event-driven and will detect changes in your library and sync that subset of your library. This is useful if you want real-time updates on your AniList profile.
 
-!!! note
+??? note "Sync Interval with Polling Scan"
 
-    Even with polling scan enabled, the sync interval will still be respected. So, every `SYNC_INTERVAL` seconds, a regular sync will be performed.
+    If `POLLING_SCAN` is enabled, the sync interval will be used to determine how often to synchronize the [mappings database](./advanced/custom-mappings.md) and your AniList profile. Periodic scans will be disabled (unless it is your first run).
 
 ### `FULL_SCAN`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,7 +89,7 @@ Interval in seconds between sync jobs. Set to `-1` to run once and exit.
 
 ??? note "Sync Interval with Polling Scan"
 
-    If `POLLING_SCAN` is enabled, the sync interval will be used to determine how often to synchronize the [mappings database](./advanced/custom-mappings.md) and your AniList profile. Periodic scans will be disabled (unless it is your first run).
+    If `POLLING_SCAN` is enabled, the sync interval will be used to determine how often to synchronize the [mappings database](./advanced/custom-mappings.md) and your AniList profile. Periodic scans will be disabled.
 
 ### `POLLING_SCAN`
 
@@ -101,7 +101,7 @@ The polling scanner is event-driven and will detect changes in your library and 
 
 ??? note "Sync Interval with Polling Scan"
 
-    If `POLLING_SCAN` is enabled, the sync interval will be used to determine how often to synchronize the [mappings database](./advanced/custom-mappings.md) and your AniList profile. Periodic scans will be disabled (unless it is your first run).
+    If `POLLING_SCAN` is enabled, the sync interval will be used to determine how often to synchronize the [mappings database](./advanced/custom-mappings.md) and your AniList profile. Periodic scans will be disabled.
 
 ### `FULL_SCAN`
 

--- a/main.py
+++ b/main.py
@@ -1,47 +1,68 @@
 import asyncio
 import signal
+from contextlib import asynccontextmanager
 
-from src import PLEX_ANIBDRIGE_HEADER, config, log
+from src import PLEXANIBDRIGE_HEADER, config, log
 from src.core import BridgeClient, SchedulerClient
 
 
-async def main():
-    """Entry point for PlexAniBridge
+@asynccontextmanager
+async def create_scheduler(bridge: BridgeClient, **scheduler_kwargs):
+    """Context manager for creating and managing scheduler lifecycle"""
+    scheduler = SchedulerClient(bridge, **scheduler_kwargs)
+    try:
+        await scheduler.start()
+        yield scheduler
+    finally:
+        await scheduler.stop()
 
-    Initializes the application and starts the scheduler.
-    """
-    log.info(f"\n{PLEX_ANIBDRIGE_HEADER}")
+
+async def main():
+    """Asynchronous entry point for PlexAniBridge"""
+    log.info(f"\n{PLEXANIBDRIGE_HEADER}")
     log.info(f"PlexAniBridge: [CONFIG] => {config}")
 
     bridge = BridgeClient(config)
-    scheduler = SchedulerClient(
-        bridge,
-        sync_interval=config.SYNC_INTERVAL,
-        polling_scan=config.POLLING_SCAN,
-        poll_interval=30,
-    )
 
-    loop = asyncio.get_event_loop()
     stop_event = asyncio.Event()
 
-    def signal_handler():
-        log.info("PlexAniBridge: Caught signal, shutting down...")
+    def signal_handler(sig: signal.Signals) -> None:
+        """Signal handler for SIGTERM and SIGINT
+
+        Args:
+            sig (signal.Signals): Signal object
+        """
+        log.info(f"Received signal {sig.name}")
         stop_event.set()
 
-    loop.add_signal_handler(signal.SIGTERM, signal_handler)
-    loop.add_signal_handler(signal.SIGINT, signal_handler)
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, lambda s=sig: signal_handler(s))
 
     try:
-        scheduler.start()
-        await stop_event.wait()
+        async with create_scheduler(
+            bridge,
+            sync_interval=config.SYNC_INTERVAL,
+            polling_scan=config.POLLING_SCAN,
+            poll_interval=30,
+        ) as _:
+            await stop_event.wait()
     except asyncio.CancelledError:
-        pass
+        log.info("PlexAniBridge: Main task cancelled")
     finally:
-        await scheduler.stop()
-        for sig in (signal.SIGTERM, signal.SIGINT):
-            loop.remove_signal_handler(sig)
-        log.info("PlexAniBridge: Exiting...")
+        tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        if tasks:
+            log.info(f"PlexAniBridge: Cleaning up {len(tasks)} remaining tasks...")
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        log.info("PlexAniBridge: Caught KeyboardInterrupt, shutting down...")
+    finally:
+        log.info("PlexAniBridge: Exiting...")

--- a/main.py
+++ b/main.py
@@ -21,15 +21,9 @@ def main():
     )
 
     try:
-        if config.SYNC_INTERVAL == -1:
-            log.info(
-                "PlexAniBridge: SYNC_INTERVAL set to -1, running once and exiting..."
-            )
-            scheduler.run_sync()
-        else:
-            scheduler.start()
-            while True:
-                time.sleep(1)
+        scheduler.start()
+        while True:
+            time.sleep(1)
     except KeyboardInterrupt:
         log.info("PlexAniBridge: Caught KeyboardInterrupt, shutting down...")
     finally:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -10,14 +10,14 @@ __email__ = "eliasbenbourenane@gmail.com"
 __version__ = get_pyproject_version()
 __git_hash__ = get_git_hash()
 
-PLEX_ANIBDRIGE_HEADER = f"""
+PLEXANIBDRIGE_HEADER = f"""
 ╔═══════════════════════════════════════════════════════════════════════════════╗
 ║                           P L E X A N I B R I D G E                           ║
 ╠═══════════════════════════════════════════════════════════════════════════════╣
 ║                                                                               ║
 ║  Version: {__version__:<68}║
 ║  Git Hash: {__git_hash__:<67}║
-║  Author: {f"{__author__ } @{__maintainer__}":<69}║
+║  Author: {f"{__author__} @{__maintainer__}":<69}║
 ║  License: {__license__:<68}║
 ║  Repository: https://github.com/eliasbenb/PlexAniBridge                       ║
 ║                                                                               ║

--- a/src/core/bridge.py
+++ b/src/core/bridge.py
@@ -294,9 +294,8 @@ class BridgeClient:
         last_sync = max(
             self.last_synced or datetime.min,
             self.last_polled or datetime.min,
-            datetime(1970, 1, 1),
         )
-
+        last_sync = datetime.now() if last_sync == datetime.min else last_sync
         items = plex_client.get_section_items(
             section,
             min_last_modified=last_sync if poll else None,

--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -1,6 +1,4 @@
-import sched
-import threading
-import time
+import asyncio
 from datetime import datetime, timedelta
 
 from src import log
@@ -20,122 +18,93 @@ class SchedulerClient:
         self.polling_scan = polling_scan
         self.poll_interval = poll_interval
 
-        self.reinit_scheduler = sched.scheduler(time.time, time.sleep)
-        self.periodic_scheduler = sched.scheduler(time.time, time.sleep)
-        self.poll_thread: threading.Thread | None = None
+        self._sync_lock = asyncio.Lock()
+        self._running = False
+        self._tasks: set[asyncio.Task] = set()
 
-        self._sync_lock = threading.Lock()
-        self._running = True
-
-    def run_sync(self, *args, **kwargs) -> None:
+    async def run_sync(self, *args, **kwargs) -> None:
         """Executes a single synchronization cycle between Plex and AniList."""
-        with self._sync_lock:
+        async with self._sync_lock:
             try:
                 self.bridge.sync(*args, **kwargs)
             except Exception as e:
                 log.error(f"{self.__class__.__name__}: Error during sync", exc_info=e)
 
-    def schedule_periodic_sync(self, scheduler: sched.scheduler) -> None:
+    async def periodic_sync(self) -> None:
         """Manages periodic execution of the sync process at fixed intervals."""
-        try:
-            self.run_sync()
-        except Exception as e:
-            log.error(
-                f"{self.__class__.__name__}: Error during periodic sync", exc_info=e
-            )
-        finally:
-            if self._running and self.sync_interval >= 0:
-                scheduler.enterabs(
-                    time.time() + self.sync_interval,
-                    1,
-                    self.schedule_periodic_sync,
-                    (scheduler,),
-                )
-                next_period = datetime.now() + timedelta(seconds=self.sync_interval)
-                log.info(
-                    f"{self.__class__.__name__}: Next periodic sync at {next_period}"
-                )
-
-    def run_poll_sync(self) -> None:
-        """Polls for changes and syncs when needed."""
         while self._running:
             try:
-                self.run_sync(poll=True)
+                await self.run_sync()
+            except Exception as e:
+                log.error(
+                    f"{self.__class__.__name__}: Error during periodic sync", exc_info=e
+                )
+
+            next_period = datetime.now() + timedelta(seconds=self.sync_interval)
+            log.info(f"{self.__class__.__name__}: Next periodic sync at {next_period}")
+            await asyncio.sleep(self.sync_interval)
+
+    async def poll_sync(self) -> None:
+        """Polls for changes and syncs when needed."""
+        while self._running:
+            start_time = asyncio.get_event_loop().time()
+
+            try:
+                await self.run_sync(poll=True)
             except Exception as e:
                 log.error(
                     f"{self.__class__.__name__}: Error during polling sync", exc_info=e
                 )
-            time.sleep(self.poll_interval)
 
-    def schedule_reinit(self, scheduler: sched.scheduler) -> None:
+            elapsed = asyncio.get_event_loop().time() - start_time
+            wait_time = max(0, self.poll_interval - elapsed)
+            await asyncio.sleep(wait_time)
+
+    async def reinit_periodic(self) -> None:
         """Reinitializes the bridge client at fixed intervals."""
-        try:
-            self.bridge.reinit()
-        except Exception as e:
-            log.error(f"{self.__class__.__name__}: Error during reinit", exc_info=e)
-        finally:
-            if self._running:
-                scheduler.enterabs(
-                    time.time() + self.sync_interval,
-                    1,
-                    self.schedule_reinit,
-                    (scheduler,),
-                )
+        while self._running:
+            try:
+                self.bridge.reinit()
+            except Exception as e:
+                log.error(f"{self.__class__.__name__}: Error during reinit", exc_info=e)
+            await asyncio.sleep(self.sync_interval)
 
     def start(self) -> None:
-        """Starts both scheduling mechanisms."""
+        """Starts all scheduling mechanisms."""
         self._running = True
+        loop = asyncio.get_event_loop()
 
-        self.reinit_scheduler.enterabs(
-            time.time(),
-            1,
-            self.schedule_reinit,
-            (self.reinit_scheduler,),
-        )
-        reinit_scheduler_thread = threading.Thread(
-            target=self.reinit_scheduler.run,
-            name="reinit_scheduler",
-            daemon=True,
-        )
-        reinit_scheduler_thread.start()
+        reinit_task = loop.create_task(self.reinit_periodic())
+        self._tasks.add(reinit_task)
+        reinit_task.add_done_callback(self._tasks.discard)
 
         if self.polling_scan:
-            self.poll_thread = threading.Thread(
-                target=self.run_poll_sync,
-                name="poll_scheduler",
-                daemon=True,
-            )
-            self.poll_thread.start()
+            poll_task = loop.create_task(self.poll_sync())
+            self._tasks.add(poll_task)
+            poll_task.add_done_callback(self._tasks.discard)
             log.info(
                 f"{self.__class__.__name__}: Started polling scheduler with interval {self.poll_interval}"
             )
         else:
-            self.periodic_scheduler.enterabs(
-                time.time(),
-                1,
-                self.schedule_periodic_sync,
-                (self.periodic_scheduler,),
-            )
-            periodic_scheduler_thread = threading.Thread(
-                target=self.periodic_scheduler.run,
-                name="periodic_scheduler",
-                daemon=True,
-            )
-            periodic_scheduler_thread.start()
+            periodic_task = loop.create_task(self.periodic_sync())
+            self._tasks.add(periodic_task)
+            periodic_task.add_done_callback(self._tasks.discard)
             log.info(
                 f"{self.__class__.__name__}: Started periodic scheduler with interval {self.sync_interval}"
             )
 
-    def stop(self) -> None:
-        """Stops both scheduling mechanisms."""
+    async def stop(self) -> None:
+        """Stops all scheduling mechanisms."""
         self._running = False
 
-        if self.periodic_scheduler:
-            for event in self.periodic_scheduler.queue:
-                self.periodic_scheduler.cancel(event)
-            log.info(f"{self.__class__.__name__}: Stopped periodic scheduler")
+        if self._tasks:
+            for task in self._tasks:
+                task.cancel()
 
-        if self.poll_thread and self.poll_thread.is_alive():
-            # Wait for poll thread to finish
-            self.poll_thread.join(timeout=0.25)
-            log.info(f"{self.__class__.__name__}: Stopped polling scheduler")
+            try:
+                await asyncio.gather(*self._tasks, return_exceptions=True)
+            except asyncio.CancelledError:
+                pass
+
+            self._tasks.clear()
+            log.info(f"{self.__class__.__name__}: Stopped all schedulers")

--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -6,105 +6,100 @@ from src.core import BridgeClient
 
 
 class SchedulerClient:
+    """Asynchronous scheduler for managing Plex-AniList synchronization"""
+
     def __init__(
         self,
         bridge: BridgeClient,
         sync_interval: int,
         polling_scan: bool,
-        poll_interval: int,
-    ) -> None:
+        poll_interval: int = 30,
+        reinit_interval: int = 3600,
+    ):
         self.bridge = bridge
         self.sync_interval = sync_interval
         self.polling_scan = polling_scan
         self.poll_interval = poll_interval
-
-        self._sync_lock = asyncio.Lock()
+        self.reinit_interval = reinit_interval
         self._running = False
         self._tasks: set[asyncio.Task] = set()
+        self._sync_lock = asyncio.Lock()
 
-    async def run_sync(self, *args, **kwargs) -> None:
-        """Executes a single synchronization cycle between Plex and AniList."""
+    async def sync(self, poll: bool = False) -> None:
+        """Execute a single synchronization cycle with error handling
+
+        Args:
+            poll (bool, optional): Flag to enable polling-based sync. Defaults to False.
+        """
         async with self._sync_lock:
             try:
-                self.bridge.sync(*args, **kwargs)
+                self.bridge.sync(poll=poll)
             except Exception as e:
-                log.error(f"{self.__class__.__name__}: Error during sync", exc_info=e)
+                log.error(f"Sync error: {e}", exc_info=True)
 
-    async def periodic_sync(self) -> None:
-        """Manages periodic execution of the sync process at fixed intervals."""
+    async def _periodic_sync(self) -> None:
+        """Handle periodic synchronization"""
         while self._running:
             try:
-                await self.run_sync()
+                await self.sync()
+                next_sync = datetime.now() + timedelta(seconds=self.sync_interval)
+                log.info(f"Next periodic sync scheduled for: {next_sync}")
+                await asyncio.sleep(self.sync_interval)
             except Exception as e:
-                log.error(
-                    f"{self.__class__.__name__}: Error during periodic sync", exc_info=e
-                )
+                log.error(f"Periodic sync error: {e}", exc_info=True)
+                await asyncio.sleep(10)
 
-            next_period = datetime.now() + timedelta(seconds=self.sync_interval)
-            log.info(f"{self.__class__.__name__}: Next periodic sync at {next_period}")
-            await asyncio.sleep(self.sync_interval)
-
-    async def poll_sync(self) -> None:
-        """Polls for changes and syncs when needed."""
+    async def _poll_sync(self) -> None:
+        """Handle polling-based synchronization"""
         while self._running:
-            start_time = asyncio.get_event_loop().time()
-
             try:
-                await self.run_sync(poll=True)
+                await self.sync(poll=True)
+                await asyncio.sleep(self.poll_interval)
             except Exception as e:
-                log.error(
-                    f"{self.__class__.__name__}: Error during polling sync", exc_info=e
-                )
+                log.error(f"Poll sync error: {e}", exc_info=True)
+                await asyncio.sleep(10)
 
-            elapsed = asyncio.get_event_loop().time() - start_time
-            wait_time = max(0, self.poll_interval - elapsed)
-            await asyncio.sleep(wait_time)
-
-    async def reinit_periodic(self) -> None:
-        """Reinitializes the bridge client at fixed intervals."""
+    async def _reinit(self) -> None:
+        """Handle periodic bridge reinitialization"""
         while self._running:
             try:
                 self.bridge.reinit()
+                await asyncio.sleep(self.reinit_interval)
             except Exception as e:
-                log.error(f"{self.__class__.__name__}: Error during reinit", exc_info=e)
-            await asyncio.sleep(self.sync_interval)
+                log.error(f"Reinit error: {e}", exc_info=True)
+                await asyncio.sleep(10)
 
-    def start(self) -> None:
-        """Starts all scheduling mechanisms."""
+    def _create_task(self, coro) -> None:
+        """Create and track an asyncio task"""
+        task = asyncio.create_task(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def start(self) -> None:
+        """Start the scheduler"""
+        if self._running:
+            return
+
         self._running = True
-        loop = asyncio.get_event_loop()
-
-        reinit_task = loop.create_task(self.reinit_periodic())
-        self._tasks.add(reinit_task)
-        reinit_task.add_done_callback(self._tasks.discard)
+        self._create_task(self._reinit())
 
         if self.polling_scan:
-            poll_task = loop.create_task(self.poll_sync())
-            self._tasks.add(poll_task)
-            poll_task.add_done_callback(self._tasks.discard)
-            log.info(
-                f"{self.__class__.__name__}: Started polling scheduler with interval {self.poll_interval}"
-            )
+            log.info(f"Starting polling scheduler (interval: {self.poll_interval}s)")
+            self._create_task(self._poll_sync())
         else:
-            periodic_task = loop.create_task(self.periodic_sync())
-            self._tasks.add(periodic_task)
-            periodic_task.add_done_callback(self._tasks.discard)
-            log.info(
-                f"{self.__class__.__name__}: Started periodic scheduler with interval {self.sync_interval}"
-            )
+            log.info(f"Starting periodic scheduler (interval: {self.sync_interval}s)")
+            self._create_task(self._periodic_sync())
 
     async def stop(self) -> None:
-        """Stops all scheduling mechanisms."""
+        """Stop the scheduler and clean up"""
         self._running = False
 
         if self._tasks:
+            log.info("Stopping all scheduler tasks...")
             for task in self._tasks:
                 task.cancel()
 
-            try:
-                await asyncio.gather(*self._tasks, return_exceptions=True)
-            except asyncio.CancelledError:
-                pass
-
+            await asyncio.gather(*self._tasks, return_exceptions=True)
             self._tasks.clear()
-            log.info(f"{self.__class__.__name__}: Stopped all schedulers")
+
+        log.info("Scheduler stopped")

--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -13,21 +13,23 @@ class SchedulerClient:
         bridge: BridgeClient,
         sync_interval: int,
         polling_scan: bool,
-        poll_interval: int = 30,
+        poll_interval: int,
     ) -> None:
         self.bridge = bridge
         self.sync_interval = sync_interval
         self.polling_scan = polling_scan
         self.poll_interval = poll_interval
 
+        self.reinit_scheduler = sched.scheduler(time.time, time.sleep)
         self.periodic_scheduler = sched.scheduler(time.time, time.sleep)
         self.poll_thread: threading.Thread | None = None
-        self.sync_lock = threading.Lock()
+
+        self._sync_lock = threading.Lock()
         self._running = True
 
     def run_sync(self, *args, **kwargs) -> None:
         """Executes a single synchronization cycle between Plex and AniList."""
-        with self.sync_lock:
+        with self._sync_lock:
             try:
                 self.bridge.sync(*args, **kwargs)
             except Exception as e:
@@ -36,14 +38,13 @@ class SchedulerClient:
     def schedule_periodic_sync(self, scheduler: sched.scheduler) -> None:
         """Manages periodic execution of the sync process at fixed intervals."""
         try:
-            self.bridge.reinit()
             self.run_sync()
         except Exception as e:
             log.error(
                 f"{self.__class__.__name__}: Error during periodic sync", exc_info=e
             )
         finally:
-            if self._running:
+            if self._running and self.sync_interval >= 0:
                 scheduler.enterabs(
                     time.time() + self.sync_interval,
                     1,
@@ -66,26 +67,37 @@ class SchedulerClient:
                 )
             time.sleep(self.poll_interval)
 
+    def schedule_reinit(self, scheduler: sched.scheduler) -> None:
+        """Reinitializes the bridge client at fixed intervals."""
+        try:
+            self.bridge.reinit()
+        except Exception as e:
+            log.error(f"{self.__class__.__name__}: Error during reinit", exc_info=e)
+        finally:
+            if self._running:
+                scheduler.enterabs(
+                    time.time() + self.sync_interval,
+                    1,
+                    self.schedule_reinit,
+                    (scheduler,),
+                )
+
     def start(self) -> None:
         """Starts both scheduling mechanisms."""
         self._running = True
 
-        if self.sync_interval >= 0:
-            self.periodic_scheduler.enterabs(
-                time.time(),
-                1,
-                self.schedule_periodic_sync,
-                (self.periodic_scheduler,),
-            )
-            scheduler_thread = threading.Thread(
-                target=self.periodic_scheduler.run,
-                name="periodic_scheduler",
-                daemon=True,
-            )
-            scheduler_thread.start()
-            log.info(
-                f"{self.__class__.__name__}: Started periodic scheduler with interval {self.sync_interval}"
-            )
+        self.reinit_scheduler.enterabs(
+            time.time(),
+            1,
+            self.schedule_reinit,
+            (self.reinit_scheduler,),
+        )
+        reinit_scheduler_thread = threading.Thread(
+            target=self.reinit_scheduler.run,
+            name="reinit_scheduler",
+            daemon=True,
+        )
+        reinit_scheduler_thread.start()
 
         if self.polling_scan:
             self.poll_thread = threading.Thread(
@@ -96,6 +108,22 @@ class SchedulerClient:
             self.poll_thread.start()
             log.info(
                 f"{self.__class__.__name__}: Started polling scheduler with interval {self.poll_interval}"
+            )
+        else:
+            self.periodic_scheduler.enterabs(
+                time.time(),
+                1,
+                self.schedule_periodic_sync,
+                (self.periodic_scheduler,),
+            )
+            periodic_scheduler_thread = threading.Thread(
+                target=self.periodic_scheduler.run,
+                name="periodic_scheduler",
+                daemon=True,
+            )
+            periodic_scheduler_thread.start()
+            log.info(
+                f"{self.__class__.__name__}: Started periodic scheduler with interval {self.sync_interval}"
             )
 
     def stop(self) -> None:
@@ -109,5 +137,5 @@ class SchedulerClient:
 
         if self.poll_thread and self.poll_thread.is_alive():
             # Wait for poll thread to finish
-            self.poll_thread.join(timeout=5)
+            self.poll_thread.join(timeout=0.25)
             log.info(f"{self.__class__.__name__}: Stopped polling scheduler")


### PR DESCRIPTION
### Description

#60 introduced polling scans. However, polling and periodic scans were run in tandem which might be misleading and not very useful. This PR separates the two completely and makes them mutually exclusive.

**Improvements:**

- Made polling scan and periodic scan mutually exclusive

**Fixes:**

- The keyboard interrupt handler not working until the third interrupt signal
