### PR TITLE
Only get mappings for TV entries with a non-null episode offset

### DIFF
--- a/src/core/animap.py
+++ b/src/core/animap.py
@@ -283,21 +283,26 @@ class AniMapClient:
             partial_conditions = []
             exact_conditions = []
 
-            if imdb:
-                partial_conditions.append(json_contains("imdb_id", imdb))
-            if tmdb:
-                if is_movie:
+            if is_movie:
+                if imdb:
+                    partial_conditions.append(json_contains("imdb_id", imdb))
+                if tmdb:
                     partial_conditions.append(json_contains("tmdb_movie_id", tmdb))
-                else:
+            else:
+                if tmdb:
                     partial_conditions.append(json_contains("tmdb_show_id", tmdb))
-            if not is_movie and tvdb:
-                partial_conditions.append(AniMap.tvdb_id == tvdb)
+                if imdb:
+                    partial_conditions.append(json_contains("imdb_id", imdb))
+                if tvdb:
+                    partial_conditions.append(AniMap.tvdb_id == tvdb)
 
-            if not is_movie:
                 if season is not None:
                     exact_conditions.append(AniMap.tvdb_season == season)
+
                 if epoffset is not None:
                     exact_conditions.append(AniMap.tvdb_epoffset == epoffset)
+                else:
+                    exact_conditions.append(AniMap.tvdb_epoffset.is_not(None))
 
             # Query with all conditions
             query = (

--- a/src/core/sync/show.py
+++ b/src/core/sync/show.py
@@ -99,8 +99,8 @@ class ShowSyncClient(BaseSyncClient[Show, Season]):
         is_partially_viewed = len(watched_episodes) > 0
         is_on_continue_watching = self.plex_client.is_on_continue_watching(
             subitem,
-            index__gt=animapping.tvdb_epoffset,
-            index__lte=animapping.tvdb_epoffset
+            index__gt=(animapping.tvdb_epoffset or 0),
+            index__lte=(animapping.tvdb_epoffset or 0)
             + (anilist_media.episodes or sys.maxsize),
         )
 
@@ -222,7 +222,7 @@ class ShowSyncClient(BaseSyncClient[Show, Season]):
             FuzzyDate | None: Start date for the media item
         """
         try:
-            episode: Episode = subitem.get(episode=animapping.tvdb_epoffset + 1)
+            episode: Episode = subitem.get(episode=(animapping.tvdb_epoffset or 0) + 1)
         except (plexapi.exceptions.NotFound, IndexError):
             return None
 
@@ -269,7 +269,7 @@ class ShowSyncClient(BaseSyncClient[Show, Season]):
         else:
             try:
                 episode: Episode = subitem.get(
-                    episode=animapping.tvdb_epoffset
+                    episode=(animapping.tvdb_epoffset or 0)
                     + (anilist_media.episodes or sys.maxsize)
                 )
             except (plexapi.exceptions.NotFound, IndexError):
@@ -330,8 +330,9 @@ class ShowSyncClient(BaseSyncClient[Show, Season]):
 
         return self.plex_client.get_episodes(
             subitem,
-            start=animapping.tvdb_epoffset + 1,
-            end=animapping.tvdb_epoffset + (anilist_media.episodes or sys.maxsize),
+            start=(animapping.tvdb_epoffset or 0) + 1,
+            end=(animapping.tvdb_epoffset or 0)
+            + (anilist_media.episodes or sys.maxsize),
         )
 
     def __filter_watched_episodes(


### PR DESCRIPTION
### Description

The mapping database was changed to include null episode offsets. This was done to allow storing incomplete entries in the database for users/maintainers to fill in. Unfortunately, this is a breaking change and will cause errors in versions prior to v0.3.2. These errors will only be logged and don't actually impact the script otherwise.

**Fixes:**

- Only get mappings for TV entries with a non-null episode offset
