### PR TITLE
Timezone awareness

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,5 @@ sqlmodel==0.0.22
 thefuzz==0.22.1
 tomlkit==0.13.2
 typing_extensions==4.12.2
+tzlocal==5.2
 urllib3==2.3.0

--- a/src/core/plex.py
+++ b/src/core/plex.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from textwrap import dedent
 
 import plexapi.utils
@@ -7,6 +7,7 @@ from cachetools.func import lru_cache
 from plexapi.library import MovieSection, ShowSection
 from plexapi.server import PlexServer
 from plexapi.video import Episode, EpisodeHistory, Movie, MovieHistory, Season, Show
+from tzlocal import get_localzone
 
 from src import log
 
@@ -144,7 +145,7 @@ class PlexClient:
         if min_last_modified:
             log.debug(
                 f"{self.__class__.__name__}: Filtering section $$'{section.title}'$$ by "
-                f"items last updated, viewed, or rated after {min_last_modified}"
+                f"items last updated, viewed, or rated after {min_last_modified.astimezone(get_localzone())}"
             )
             filters["and"].append(
                 {
@@ -166,7 +167,7 @@ class PlexClient:
                 {
                     "or": [
                         {"unwatched": False},
-                        {"lastRatedAt>>=": datetime(1970, 1, 1)},
+                        {"lastRatedAt>>=": datetime(1970, 1, 1, tzinfo=timezone.utc)},
                     ]
                 }
             )

--- a/src/models/anilist.py
+++ b/src/models/anilist.py
@@ -318,7 +318,7 @@ class FuzzyDate(AniListBaseModel):
         """
         return FuzzyDate(year=d.year, month=d.month, day=d.day)
 
-    def to_datetime(self) -> datetime | None:
+    def to_datetime(self, *args, **kwargs) -> datetime | None:
         """Convert the FuzzyDate to a datetime object
 
         Returns:
@@ -326,7 +326,13 @@ class FuzzyDate(AniListBaseModel):
         """
         if not self.year:
             return None
-        return datetime(year=self.year, month=self.month or 1, day=self.day or 1)
+        return datetime(
+            year=self.year,
+            month=self.month or 1,
+            day=self.day or 1,
+            *args,
+            **kwargs,
+        )
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, FuzzyDate):


### PR DESCRIPTION
### Description

This PR adds timezone awareness throughout PlexAniBridge to prevent inconsistencies when switching timezones across sync jobs.

**What's new:**

- AniList start and complete dates will now be converted to the AniList user's configured timezone

**Improvements:**

- Start/completed dates should be a little more accurate

**Fixes:**

- Inconsistencies in started/completed dates when switching timezones between sync jobs
- The polling scanner will now consider timezone changes, preventing skipped scans if the user's timezone changes

### Issues Fixed or Closed by this PR

- Closes #35 
