### PR TITLE
Log/warn about duplicate custom mappings

### DIFF
--- a/src/core/animap.py
+++ b/src/core/animap.py
@@ -125,15 +125,6 @@ class AniMapClient:
                         if anilist_id_str.startswith("$"):
                             continue
 
-                        for attr in (
-                            "mal_id",
-                            "imdb_id",
-                            "tmdb_movie_id",
-                            "tmdb_show_id",
-                        ):
-                            if attr in data:
-                                data[attr] = single_val_to_list(data[attr])
-
                         try:
                             AniMap.model_validate(
                                 {

--- a/src/models/animap.py
+++ b/src/models/animap.py
@@ -1,3 +1,4 @@
+from pydantic import field_validator
 from sqlmodel import JSON, Field, SQLModel
 
 
@@ -15,6 +16,16 @@ class AniMap(SQLModel, table=True):
     tvdb_id: int | None = Field(index=True)
     tvdb_epoffset: int | None
     tvdb_season: int | None
+
+    @field_validator(
+        "imdb_id", "mal_id", "tmdb_movie_id", "tmdb_show_id", mode="before"
+    )
+    def convert_to_list(cls, v):
+        if v is None:
+            return v
+        if not isinstance(v, list):
+            return [v]
+        return v
 
     def __hash__(self) -> int:
         return hash(self.__repr__())


### PR DESCRIPTION
### Description

To make cleaning up deprecated custom mappings easier, this PR adds logging/warning upon startup for duplicate mapping entries.

**What's new:**

- Log/warn about duplicate custom mappings. E.g.:

  ```
  25-02-13 01:03:20 - PlexAniBridge - DEBUG animap.py:188   AniMapClient: Found a partial duplicate entry in your custom mappings {anilist_id: 1}
  25-02-13 01:03:20 - PlexAniBridge - WARNING   animap.py:188   AniMapClient: Found an exact duplicate entry in your custom mappings {anilist_id: 2}
  ```

### Issues Fixed or Closed by this PR

- Closes #84 
