### PR TITLE
Optomization to the sync clients

### DIFF
--- a/src/core/bridge.py
+++ b/src/core/bridge.py
@@ -275,15 +275,7 @@ class BridgeClient:
             f"$$'{anilist_client.user.name}'$$ completed"
         )
 
-        unsynced_items = sorted(
-            list(sync_stats.possible - sync_stats.covered),
-            key=lambda x: (
-                x.type,
-                getattr(x, "parentRatingKey", 0),
-                getattr(x, "parentIndex", 0),
-                getattr(x, "index", 0),
-            ),
-        )
+        unsynced_items = sorted(list(sync_stats.possible - sync_stats.covered))
         unsynced_items_str = ", ".join(str(i) for i in unsynced_items)
         log.debug(
             f"{self.__class__.__name__}: The following items could not be synced: {unsynced_items_str}"

--- a/src/core/sync/base.py
+++ b/src/core/sync/base.py
@@ -107,8 +107,8 @@ class SyncStats(BaseModel, arbitrary_types_allowed=True):
     not_found: int = 0
     failed: int = 0
 
-    possible: set[E] = set()
-    covered: set[E] = set()
+    possible: set[str] = set()
+    covered: set[str] = set()
 
     @property
     def coverage(self) -> float:
@@ -241,7 +241,7 @@ class BaseSyncClient(ABC, Generic[T, S, E]):
                     anilist_media=anilist_media,
                     animapping=animapping,
                 )
-                self.sync_stats.covered |= set(grandchild_items)
+                self.sync_stats.covered |= {str(e) for e in grandchild_items}
             except Exception:
                 log.error(
                     f"{self.__class__.__name__}: Failed to process {item.type} "

--- a/src/core/sync/movie.py
+++ b/src/core/sync/movie.py
@@ -22,7 +22,7 @@ class MovieSyncClient(BaseSyncClient[Movie, Movie, list[Movie]]):
         Returns:
             Iterator[tuple[Movie, list[Movie], AniMap | None, Media | None]]: Mapping matches (child, grandchild, animapping, anilist_media)
         """
-        self.sync_stats.possible.add(item)
+        self.sync_stats.possible.add(str(item))
 
         guids = ParsedGuids.from_guids(item.guids)
 

--- a/src/core/sync/show.py
+++ b/src/core/sync/show.py
@@ -35,7 +35,7 @@ class ShowSyncClient(BaseSyncClient[Show, Season, list[Episode]]):
             e for e in item.episodes() if e.parentIndex in seasons
         ]
 
-        self.sync_stats.possible |= set(all_episodes)
+        self.sync_stats.possible |= {str(e) for e in all_episodes}
         unyielded_seasons = set(seasons.keys())
 
         for animapping in self.animap_client.get_mappings(


### PR DESCRIPTION
### Description

This PR greatly optimizes RAM usage and processing speed for the sync clients.

**Improvements:**

- Only calculate the AniList synced fields when absolutely necessary to prevent wasted processing time
- Store items used in coverage calculations as their string representations to greatly reduce RAM usage and processing time when comparing object hashes
- Don't uselessly redefine functions and variables within function calls