### PR TITLE
Pulling activity from the Plex community server

### DIFF
--- a/src/core/plexapi/discover.py
+++ b/src/core/plexapi/discover.py
@@ -238,7 +238,7 @@ class DiscoverVideo(Video, DiscoverPlexObject):
 
     @original_server
     def history(self, *args, **kwargs):
-        return self._server.history(ratingKey=self._ratingKey, *args, **kwargs)
+        return self._server.history(ratingKey=self.guid, *args, **kwargs)
 
 
 class DiscoverMovie(Movie, DiscoverVideo):


### PR DESCRIPTION
### Description

This PR adds more capabilities to the discover metadata source. It allows for pulling watch history from the `community.plex.tv` API.

**What's new:**

- Pulling watch history from `community.plex.tv`
- The discover metadata source will fall back to checking the local server for continue watching status

**Fixes:**

- Error caused by referncing non existent attributes
