### PR TITLE
Migrate from sqlmodel to sqlalchemy

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -5,22 +5,20 @@ import sys
 from logging.config import fileConfig
 
 from sqlalchemy import create_engine
-from sqlmodel import SQLModel
 
 from alembic import context
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
 
+import src.models  # noqa: F401
 from src import config as app_config
-from src.models.animap import AniMap  # noqa: F401
-from src.models.housekeeping import Housekeeping  # noqa: F401
 
 config = context.config
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-target_metadata = SQLModel.metadata
+target_metadata = src.models.Base.metadata
 
 db_url = f"sqlite:///{app_config.DATA_PATH / 'plexanibridge.db'}"
 config.set_main_option("sqlalchemy.url", db_url)

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -9,7 +9,6 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
-import sqlmodel # added
 ${imports if imports else ""}
 
 # revision identifiers, used by Alembic.

--- a/alembic/versions/2024-12-21-11-56_6e710e6677c0.py
+++ b/alembic/versions/2024-12-21-11-56_6e710e6677c0.py
@@ -9,7 +9,6 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
-import sqlmodel # added
 
 
 # revision identifiers, used by Alembic.
@@ -40,8 +39,8 @@ def upgrade() -> None:
     op.create_index(op.f('ix_animap_tmdb_show_id'), 'animap', ['tmdb_show_id'], unique=False)
     op.create_index(op.f('ix_animap_tvdb_id'), 'animap', ['tvdb_id'], unique=False)
     op.create_table('house_keeping',
-    sa.Column('key', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
-    sa.Column('value', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    sa.Column('key', sa.String(), nullable=False),
+    sa.Column('value', sa.String(), nullable=True),
     sa.PrimaryKeyConstraint('key')
     )
     # ### end Alembic commands ###

--- a/alembic/versions/2025-01-15-15-52_b2ad27e14048.py
+++ b/alembic/versions/2025-01-15-15-52_b2ad27e14048.py
@@ -7,7 +7,6 @@ Create Date: 2025-01-15 15:52:56.167462
 """
 
 import sqlalchemy as sa
-from sqlmodel import JSON
 
 from alembic import op
 
@@ -24,10 +23,10 @@ def upgrade() -> None:
         "animap_new",
         sa.Column("anilist_id", sa.Integer, primary_key=True),
         sa.Column("anidb_id", sa.Integer, primary_key=False, nullable=True),
-        sa.Column("imdb_id", JSON(none_as_null=True), nullable=True),
-        sa.Column("mal_id", JSON(none_as_null=True), nullable=True),
-        sa.Column("tmdb_movie_id", JSON(none_as_null=True), nullable=True),
-        sa.Column("tmdb_show_id", JSON(none_as_null=True), nullable=True),
+        sa.Column("imdb_id", sa.JSON(none_as_null=True), nullable=True),
+        sa.Column("mal_id", sa.JSON(none_as_null=True), nullable=True),
+        sa.Column("tmdb_movie_id", sa.JSON(none_as_null=True), nullable=True),
+        sa.Column("tmdb_show_id", sa.JSON(none_as_null=True), nullable=True),
         sa.Column("tvdb_id", sa.Integer, nullable=True),
         sa.Column("tvdb_epoffset", sa.Integer, nullable=True),
         sa.Column("tvdb_season", sa.Integer, nullable=True),
@@ -59,10 +58,10 @@ def downgrade() -> None:
             "anilist_id", sa.Integer, primary_key=True, nullable=False
         ),  # Revert to original primary key
         sa.Column("anidb_id", sa.Integer, nullable=True),
-        sa.Column("imdb_id", JSON(none_as_null=True), nullable=True),
-        sa.Column("mal_id", JSON(none_as_null=True), nullable=True),
-        sa.Column("tmdb_movie_id", JSON(none_as_null=True), nullable=True),
-        sa.Column("tmdb_show_id", JSON(none_as_null=True), nullable=True),
+        sa.Column("imdb_id", sa.JSON(none_as_null=True), nullable=True),
+        sa.Column("mal_id", sa.JSON(none_as_null=True), nullable=True),
+        sa.Column("tmdb_movie_id", sa.JSON(none_as_null=True), nullable=True),
+        sa.Column("tmdb_show_id", sa.JSON(none_as_null=True), nullable=True),
         sa.Column("tvdb_id", sa.Integer, nullable=True),
         sa.Column("tvdb_epoffset", sa.Integer, nullable=True),
         sa.Column("tvdb_season", sa.Integer, nullable=True),

--- a/alembic/versions/2025-02-04-01-57_424fe94c2c03.py
+++ b/alembic/versions/2025-02-04-01-57_424fe94c2c03.py
@@ -9,7 +9,6 @@ Create Date: 2025-02-04 01:57:53.836952
 from typing import Sequence, Union
 
 import sqlalchemy as sa
-import sqlmodel  # added
 
 from alembic import op
 

--- a/alembic/versions/2025-02-15-02-10_ddbadb26481f.py
+++ b/alembic/versions/2025-02-15-02-10_ddbadb26481f.py
@@ -9,8 +9,6 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
-import sqlmodel # added
-
 
 # revision identifiers, used by Alembic.
 revision: str = 'ddbadb26481f'

--- a/alembic/versions/2025-02-17-14-29_c5581ec025a7.py
+++ b/alembic/versions/2025-02-17-14-29_c5581ec025a7.py
@@ -8,7 +8,6 @@ Create Date: 2025-02-17 14:29:10.113697
 from typing import Sequence, Union
 
 import sqlalchemy as sa
-import sqlmodel  # added
 
 from alembic import op
 

--- a/alembic/versions/2025-02-17-20-24_6b471e97e780.py
+++ b/alembic/versions/2025-02-17-20-24_6b471e97e780.py
@@ -9,7 +9,6 @@ Create Date: 2025-02-17 20:24:50.010412
 from typing import Sequence, Union
 
 import sqlalchemy as sa
-import sqlmodel  # added
 
 from alembic import op
 

--- a/alembic/versions/2025-03-24-02-37_e89ead9178d7.py
+++ b/alembic/versions/2025-03-24-02-37_e89ead9178d7.py
@@ -7,10 +7,9 @@ Create Date: 2025-03-24 02:37:18.107721
 """
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
-import sqlmodel # added
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = 'e89ead9178d7'

--- a/alembic/versions/2025-06-26-05-56_08f39c25b391.py
+++ b/alembic/versions/2025-06-26-05-56_08f39c25b391.py
@@ -7,10 +7,9 @@ Create Date: 2025-06-26 05:56:19.495133
 """
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
-import sqlmodel # added
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = '08f39c25b391'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "rapidfuzz>=3.13.0",
     "requests>=2.32.3",
-    "sqlmodel>=0.0.24",
+    "sqlalchemy>=2.0.41",
     "tomlkit>=0.13.2",
     "tzlocal>=5.3.1",
 ]

--- a/src/config/database.py
+++ b/src/config/database.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 from types import TracebackType
 
+from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
-from sqlmodel import Session, create_engine
+from sqlalchemy.orm import Session
 
 from src import __file__ as src_file
 from src import config
@@ -14,7 +15,7 @@ class PlexAniBridgeDB:
     """Database manager for PlexAniBridge application.
 
     Handles the creation, initialization, and migration of the SQLite database,
-    including file system operations and schema management. Uses SQLModel for ORM
+    including file system operations and schema management. Uses SQLAlchemy for ORM
     and Alembic for database migrations.
 
     During initialization, this class automatically imports all database models
@@ -48,7 +49,7 @@ class PlexAniBridgeDB:
 
         Performs the following setup steps:
         1. Validates or creates the data directory
-        2. Imports database models to register them with SQLModel
+        2. Imports database models to register them with SQLAlchemy
         3. Creates a SQLAlchemy engine for database connections
 
         Returns:
@@ -58,8 +59,7 @@ class PlexAniBridgeDB:
             PermissionError: If unable to create the data directory
             ValueError: If data_path exists but is a file instead of a directory
         """
-        import src.models.animap  # noqa: F401
-        import src.models.housekeeping  # noqa: F401
+        import src.models  # noqa: F401
 
         if not self.data_path.exists():
             try:

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,5 @@
+from src.models.animap import AniMap
+from src.models.base import Base
+from src.models.housekeeping import Housekeeping
+
+__all__ = ["Base", "AniMap", "Housekeeping"]

--- a/src/models/animap.py
+++ b/src/models/animap.py
@@ -1,40 +1,61 @@
 from functools import cached_property
-from typing import Any
 
-from pydantic import field_validator
-from sqlmodel import JSON, Field, Index, SQLModel
+from sqlalchemy import JSON, Index, Integer
+from sqlalchemy.orm import Mapped, mapped_column
 
+from src.models.base import Base
 from src.models.mapping import TVDBMapping
 
 
-def TypedJson(*args, **kwargs) -> Any:
-    return JSON(*args, **kwargs)
-
-
-class AniMap(SQLModel, table=True):
+class AniMap(Base):
     """Model for the animap table."""
 
-    __tablename__: str = "animap"  #  type: ignore
+    __tablename__ = "animap"
 
-    anilist_id: int = Field(primary_key=True)
-    anidb_id: int | None = Field(index=False)
-    imdb_id: list[str] | None = Field(sa_type=TypedJson(none_as_null=True), index=True)
-    mal_id: list[int] | None = Field(sa_type=TypedJson(none_as_null=True), index=False)
-    tmdb_movie_id: list[int] | None = Field(
-        sa_type=TypedJson(none_as_null=True), index=True
+    anilist_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    anidb_id: Mapped[int | None] = mapped_column(Integer, index=False, nullable=True)
+    imdb_id: Mapped[list[str] | None] = mapped_column(JSON, index=True, nullable=True)
+    mal_id: Mapped[list[int] | None] = mapped_column(JSON, index=False, nullable=True)
+    tmdb_movie_id: Mapped[list[int] | None] = mapped_column(
+        JSON, index=True, nullable=True
     )
-    tmdb_show_id: list[int] | None = Field(
-        sa_type=TypedJson(none_as_null=True), index=True
+    tmdb_show_id: Mapped[list[int] | None] = mapped_column(
+        JSON, index=True, nullable=True
     )
-    tvdb_id: int | None = Field(index=True)
-    tvdb_mappings: dict[str, str] | None = Field(
-        sa_type=TypedJson(none_as_null=True), index=True
+    tvdb_id: Mapped[int | None] = mapped_column(Integer, index=True, nullable=True)
+    tvdb_mappings: Mapped[dict[str, str] | None] = mapped_column(
+        JSON, index=True, nullable=True
     )
 
     __table_args__ = (
         Index("idx_imdb_tmdb", "imdb_id", "tmdb_movie_id"),
         Index("idx_tvdb_season", "tvdb_id", "tvdb_mappings"),
     )
+
+    def __init__(self, **kwargs) -> None:
+        """Initialize AniMap with data validation."""
+        # Convert single values to lists for specific fields
+        for field in ("imdb_id", "mal_id", "tmdb_movie_id", "tmdb_show_id"):
+            if field in kwargs:
+                kwargs[field] = self._convert_to_list(kwargs[field])
+
+        super().__init__(**kwargs)
+
+    @staticmethod
+    def _convert_to_list(v) -> list | None:
+        """Convert single values to lists.
+
+        Args:
+            v: Value to convert
+
+        Returns:
+            list | None: List of values
+        """
+        if v is None:
+            return v
+        if not isinstance(v, list):
+            return [v]
+        return v
 
     @cached_property
     def length(self) -> int:
@@ -55,27 +76,8 @@ class AniMap(SQLModel, table=True):
                 continue
         return res
 
-    @field_validator(
-        "imdb_id", "mal_id", "tmdb_movie_id", "tmdb_show_id", mode="before"
-    )
-    def convert_to_list(cls, v) -> list | None:
-        """Convert single values to lists.
-
-        Args:
-            cls: Class instance
-            v: Value to convert
-
-        Returns:
-            list | None: List of values
-        """
-        if v is None:
-            return v
-        if not isinstance(v, list):
-            return [v]
-        return v
-
     def __hash__(self) -> int:
         return hash(self.__repr__())
 
     def __repr__(self):
-        return f"<{':'.join(f'{k}={v}' for k, v in self.model_dump().items() if v is not None)}>"
+        return f"<{':'.join(f'{k}={v}' for k, v in self.__dict__.items() if v is not None and not k.startswith('_'))}>"

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -1,0 +1,7 @@
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Base class for all database models."""
+
+    pass

--- a/src/models/housekeeping.py
+++ b/src/models/housekeeping.py
@@ -1,13 +1,16 @@
-from sqlmodel import Field, SQLModel
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.base import Base
 
 
-class Housekeeping(SQLModel, table=True):
+class Housekeeping(Base):
     """Model for the Housekeeping table.
 
     This table is used to store miscellaneous data such as timestamps and hashes.
     """
 
-    __tablename__: str = "house_keeping"  # type: ignore
+    __tablename__ = "house_keeping"
 
-    key: str = Field(primary_key=True)
-    value: str | None
+    key: Mapped[str] = mapped_column(String, primary_key=True)
+    value: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/uv.lock
+++ b/uv.lock
@@ -864,7 +864,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rapidfuzz" },
     { name = "requests" },
-    { name = "sqlmodel" },
+    { name = "sqlalchemy" },
     { name = "tomlkit" },
     { name = "tzlocal" },
 ]
@@ -890,7 +890,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "rapidfuzz", specifier = ">=3.13.0" },
     { name = "requests", specifier = ">=2.32.3" },
-    { name = "sqlmodel", specifier = ">=0.0.24" },
+    { name = "sqlalchemy", specifier = ">=2.0.41" },
     { name = "tomlkit", specifier = ">=0.13.2" },
     { name = "tzlocal", specifier = ">=5.3.1" },
 ]
@@ -1422,19 +1422,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/2e/677c17c5d6a004c3c45334ab1dbe7b7deb834430b282b8a0f75ae220c8eb/sqlalchemy-2.0.41-cp313-cp313-win32.whl", hash = "sha256:bfc9064f6658a3d1cadeaa0ba07570b83ce6801a1314985bf98ec9b95d74e15f", size = 2082420, upload-time = "2025-05-14T17:55:52.69Z" },
     { url = "https://files.pythonhosted.org/packages/e9/61/e8c1b9b6307c57157d328dd8b8348ddc4c47ffdf1279365a13b2b98b8049/sqlalchemy-2.0.41-cp313-cp313-win_amd64.whl", hash = "sha256:82ca366a844eb551daff9d2e6e7a9e5e76d2612c8564f58db6c19a726869c1df", size = 2108329, upload-time = "2025-05-14T17:55:54.495Z" },
     { url = "https://files.pythonhosted.org/packages/1c/fc/9ba22f01b5cdacc8f5ed0d22304718d2c758fce3fd49a5372b886a86f37c/sqlalchemy-2.0.41-py3-none-any.whl", hash = "sha256:57df5dc6fdb5ed1a88a1ed2195fd31927e705cad62dedd86b46972752a80f576", size = 1911224, upload-time = "2025-05-14T17:39:42.154Z" },
-]
-
-[[package]]
-name = "sqlmodel"
-version = "0.0.24"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "sqlalchemy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/86/4b/c2ad0496f5bdc6073d9b4cef52be9c04f2b37a5773441cc6600b1857648b/sqlmodel-0.0.24.tar.gz", hash = "sha256:cc5c7613c1a5533c9c7867e1aab2fd489a76c9e8a061984da11b4e613c182423", size = 116780, upload-time = "2025-03-07T05:43:32.887Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/91/484cd2d05569892b7fef7f5ceab3bc89fb0f8a8c0cde1030d383dbc5449c/sqlmodel-0.0.24-py3-none-any.whl", hash = "sha256:6778852f09370908985b667d6a3ab92910d0d5ec88adcaf23dbc242715ff7193", size = 28622, upload-time = "2025-03-07T05:43:30.37Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

This PR migrates the entire data layer from SQLModel to pure SQLAlchemy while maintaining full type safety through Mapped annotations. This migration provides better performance, more granular control over database operations, and eliminates dependencies on SQLModel while preserving all existing functionality.

**Improvements:**

- Direct SQLAlchemy usage eliminates SQLModel overhead
- Better long-term compatibility with SQLAlchemy ecosystem
