### PR TITLE
Restore and undo syncs from the web UI

### DIFF
--- a/docs/recovery/disaster-recovery.md
+++ b/docs/recovery/disaster-recovery.md
@@ -3,7 +3,7 @@ title: Disaster Recovery
 icon: material/weather-cloudy-alert
 ---
 
-Given that software will always be susceptible to bugs, PlexAniBridge offers a backup and restore feature to help you recover from any data loss.
+Given that software will always be susceptible to bugs, PlexAniBridge offers multiple recovery features: daily automatic AniList backups, in-app restore, and a per‑sync undo capability on the timeline.
 
 !!! tip "Prevention"
 
@@ -11,26 +11,57 @@ Given that software will always be susceptible to bugs, PlexAniBridge offers a b
 
 ## Backups
 
-Before any scheduled sync job, PlexAniBridge will create a backup of your current AniList data. These backups are stored under the data folder (defined in `PAB_DATA_PATH`) in the `backups` directory as JSON files.
+PlexAniBridge creates a JSON snapshot of the current AniList list data on startup and on a daily schedule. These backups are stored under the data folder (defined in `PAB_DATA_PATH`) in the `backups` directory as JSON files named like:
 
-!!! warning
-
-    These backups are automatically deleted after 7 days.
-
-## Restoring from Backups
-
-To restore from a backup, use the [restore script](https://github.com/eliasbenb/PlexAniBridge/blob/HEAD/scripts/anilist_restore.py) in the `scripts` folder. You will need to pass the backup file and AniList token as arguments:
-
-```shell
-pip install requests pydantic # Python 3.10+
-python scripts/anilist_restore.py --token "$ANILIST_TOKEN" "./data/backups/plexanibridge-$ANILIST_USERNAME.$BACKUP_TIME.json"
+```
+plexanibridge-<ANILIST_USERNAME>.<YYYYMMDDHHMMSS>.json
 ```
 
-!!! tip "Restoring With Docker"
+You can work with these backups in two ways:
 
-    If you are using Docker, you can run the restore script inside your Docker container:
+1. Web UI (recommended for most cases) - browse, preview, and restore directly.
+2. CLI [restore script](https://github.com/eliasbenb/PlexAniBridge/blob/HEAD/scripts/anilist_restore.py) (legacy, deprecated).
 
-    ```shell
-    # docker exec -it plexanibridge ls /config/backups
-    docker exec -it plexanibridge python scripts/anilist_restore.py --token "$ANILIST_TOKEN" "/config/backups/plexanibridge-$ANILIST_USERNAME.$BACKUP_TIME.json"
-    ```
+!!! warning
+    Backups are automatically deleted after 7 days (rolling retention). If you need to keep a snapshot longer, save it in a safe location.
+
+### Viewing & Restoring Backups in the Web UI
+
+1. Open the Web UI and navigate to: Backups → select a profile.
+2. You will see a table of recent backups (filename, created time, size, age, detected user if available).
+3. Click Preview to open a highlighted JSON view (no data is changed).
+4. Click Restore to apply that snapshot back to AniList for the profile.
+5. A toast will indicate success; any individual sync outcomes will appear later on the timeline.
+
+#### What a Web UI Restore Does
+
+- Replays the backed-up list entries to AniList, overwriting current state for that profile's lists.
+- Only the selected backup file is used—other backups remain untouched.
+- Errors encountered during restore are summarized (restored / skipped / errors).
+
+!!! danger "Irreversible Overwrite"
+    A restore replaces current AniList list entries with the backup content. If you want a safety net, trigger a manual sync first so a fresh pre‑restore backup is generated, or download the current latest backup file.
+
+## Restoring from Backups (CLI Script)
+
+_This method is no longer recommended for typical users; prefer the Web UI above._
+
+To restore from a backup without the Web UI, use the [restore script](https://github.com/eliasbenb/PlexAniBridge/blob/HEAD/scripts/anilist_restore.py) in the `scripts` folder. You will need to pass the backup file and AniList token as arguments:
+
+## Undoing Individual Sync Changes
+
+In addition to full restores, you can undo specific sync operations directly from the Timeline page.
+
+### How It Works
+
+Each timeline entry representing a change (e.g. a creation, update, or deletion) exposes an Undo button when it is logically reversible. When clicked, PlexAniBridge applies an inverse operation to restore the previous state and creates a new timeline entry marked as `undone`.
+
+### Undo Is Available When
+
+| Original Outcome | Before State | After State | Meaning       | Undo Action      |
+| ---------------- | ------------ | ----------- | ------------- | ---------------- |
+| synced           | present      | present     | Updated entry | Revert to before |
+| synced           | null         | present     | Created entry | Delete it        |
+| deleted          | present      | null        | Deleted entry | Restore it       |
+
+_Note: Undos that are supposed to cause an entry deletion will not take effect if [DESTRUCTIVE_SYNC](../configuration.md#destructive_sync) is disabled._

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 
     import {
         Activity,
+        ArchiveRestore,
         Github,
         LayoutDashboard,
         List,
@@ -140,6 +141,12 @@
                 class="nav-link {active('/logs') ? 'nav-link-active' : ''}"
                 aria-current={active("/logs") ? "page" : undefined}
                 ><Terminal class="inline h-4 w-4" /><span>Logs</span></a
+            >
+            <a
+                href={resolve("/backups")}
+                class="nav-link {active('/backups') ? 'nav-link-active' : ''}"
+                aria-current={active("/backups") ? "page" : undefined}
+                ><ArchiveRestore class="inline h-4 w-4" /><span>Backups</span></a
             >
             <div
                 class="mt-4 px-3 text-[10px] font-semibold tracking-wider text-slate-500 uppercase"

--- a/frontend/src/routes/backups/+page.svelte
+++ b/frontend/src/routes/backups/+page.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+
+    import { ArchiveRestore, Folder, LoaderCircle } from "@lucide/svelte";
+
+    import { resolve } from "$app/paths";
+    import { apiJson } from "$lib/api";
+
+    interface StatusResponse {
+        profiles: Record<string, unknown>;
+    }
+
+    let profiles: string[] = $state([]);
+    let loading = $state(true);
+
+    async function load() {
+        loading = true;
+        try {
+            const data = await apiJson<StatusResponse>("/api/status");
+            profiles = Object.keys(data.profiles || {}).sort();
+        } catch (e) {
+            console.error(e);
+        } finally {
+            loading = false;
+        }
+    }
+
+    onMount(load);
+</script>
+
+<div class="space-y-6">
+    <div class="space-y-1">
+        <div class="flex items-center gap-2">
+            <ArchiveRestore class="inline h-4 w-4 text-slate-300" />
+            <h2 class="text-lg font-semibold">Backups</h2>
+            <span class="hidden text-xs text-slate-500 sm:inline"
+                >{Object.keys(profiles).length} profiles
+                <div class="ml-auto"></div>
+            </span>
+        </div>
+        <p class="text-xs text-slate-400">Restore from backups for each profile.</p>
+    </div>
+    {#if loading}
+        <div class="flex items-center gap-2 text-sm text-sky-300">
+            <LoaderCircle class="inline h-5 w-5 animate-spin" /> Loading…
+        </div>
+    {:else if !profiles.length}
+        <p class="text-sm text-slate-500">No profiles loaded.</p>
+    {:else}
+        <ul class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {#each profiles as p (p)}
+                <li>
+                    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                    <a
+                        href={resolve(`/backups/${p}`)}
+                        class="group block overflow-hidden rounded-md border border-slate-800 bg-gradient-to-br from-slate-900/70 to-slate-800/40 p-4 shadow-sm backdrop-blur-sm transition hover:border-slate-700 hover:from-slate-800/70 hover:to-slate-700/40 hover:shadow-md"
+                    >
+                        <div class="flex items-center gap-2">
+                            <Folder
+                                class="inline h-5 w-5 text-sky-400 transition-colors group-hover:text-sky-300"
+                            />
+                            <span class="truncate font-medium">{p}</span>
+                        </div>
+                        <p class="mt-2 text-[11px] text-slate-500">
+                            View backups for profile.
+                        </p>
+                    </a>
+                </li>
+            {/each}
+        </ul>
+    {/if}
+</div>

--- a/frontend/src/routes/backups/[profile]/+page.svelte
+++ b/frontend/src/routes/backups/[profile]/+page.svelte
@@ -1,0 +1,287 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+
+    import { ArchiveRestore, Eye, LoaderCircle, RefreshCcw } from "@lucide/svelte";
+
+    import { apiJson } from "$lib/api";
+    import { toast } from "$lib/notify";
+    import { highlightJson } from "$lib/utils";
+
+    const { params } = $props<{ params: { profile: string } }>();
+
+    let backups: BackupMeta[] = $state([]);
+    let loading = $state(true);
+    let restoring = $state<string | null>(null);
+    let previewing = $state<string | null>(null); // filename currently previewed (modal)
+    interface BackupRawPreview {
+        user?: unknown;
+        lists?: unknown;
+        [k: string]: unknown; // flexible structure
+    }
+    let previewCache = $state<Record<string, BackupRawPreview>>({});
+    let previewLoading = $state(false);
+
+    async function load() {
+        loading = true;
+        try {
+            backups = await listBackups(params.profile);
+        } catch (e) {
+            console.error(e);
+        } finally {
+            loading = false;
+        }
+    }
+
+    interface BackupMeta {
+        filename: string;
+        created_at: string;
+        size_bytes: number;
+        entries?: number | null;
+        user?: string | null;
+        age_seconds: number;
+    }
+
+    interface RestoreSummary {
+        ok: boolean;
+        filename: string;
+        total_entries: number;
+        processed: number;
+        restored: number;
+        skipped: number;
+        errors: { [k: string]: unknown }[];
+        elapsed_seconds: number;
+    }
+
+    async function listBackups(profile: string): Promise<BackupMeta[]> {
+        const data = await apiJson<{ backups: BackupMeta[] }>(
+            `/api/backups/${profile}`,
+        );
+        return data.backups || [];
+    }
+
+    async function restoreBackup(
+        profile: string,
+        filename: string,
+    ): Promise<RestoreSummary> {
+        return await apiJson<RestoreSummary>(`/api/backups/${profile}/restore`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ filename }),
+        });
+    }
+
+    async function openPreview(filename: string) {
+        if (previewing === filename) return;
+        if (!previewCache[filename]) {
+            previewLoading = true;
+            try {
+                const data = await apiJson<BackupRawPreview>(
+                    `/api/backups/${params.profile}/raw/${filename}`,
+                );
+                previewCache[filename] = data;
+            } catch (e) {
+                console.error(e);
+                toast("Failed to load preview", "error");
+                previewLoading = false;
+                return;
+            }
+            previewLoading = false;
+        }
+        previewing = filename;
+    }
+
+    function closePreview() {
+        previewing = null;
+    }
+
+    function humanBytes(n: number) {
+        if (n < 1024) return n + " B";
+        const units = ["KB", "MB", "GB"];
+        let u = -1;
+        let v = n;
+        do {
+            v /= 1024;
+            u++;
+        } while (v >= 1024 && u < units.length - 1);
+        return v.toFixed(v >= 10 ? 0 : 1) + " " + units[u];
+    }
+
+    function ageLabel(sec: number) {
+        if (sec < 90) return Math.round(sec) + "s ago";
+        if (sec < 3600) return Math.round(sec / 60) + "m ago";
+        if (sec < 86400) return Math.round(sec / 3600) + "h ago";
+        return Math.round(sec / 86400) + "d ago";
+    }
+
+    async function doRestore(filename: string) {
+        if (
+            !confirm(
+                `Restore '${filename}'? This overwrites current AniList list entries.`,
+            )
+        )
+            return;
+        restoring = filename;
+        try {
+            const res = await restoreBackup(params.profile, filename);
+            toast(
+                `Restore complete: ${res.restored}/${res.total_entries}`,
+                res.errors.length ? "warn" : "success",
+            );
+        } catch (e) {
+            console.error(e);
+            toast("Restore failed", "error");
+        } finally {
+            restoring = null;
+        }
+    }
+
+    onMount(load);
+</script>
+
+<div class="space-y-6">
+    <div class="flex flex-wrap items-center gap-2">
+        <ArchiveRestore class="inline h-4 w-4 text-slate-300" />
+        <h2 class="text-lg font-semibold">Backups</h2>
+        <span class="text-xs text-slate-500">profile: <i>{params.profile}</i></span>
+        <div class="ml-auto flex items-center gap-2 text-[11px]">
+            <button
+                onclick={load}
+                type="button"
+                class="inline-flex items-center gap-1 rounded-md border border-slate-600/60 bg-slate-700/40 px-2 py-1 font-medium text-slate-200 hover:bg-slate-600/50"
+            >
+                <RefreshCcw class="inline h-4 w-4 text-[14px]" /> Reload
+            </button>
+        </div>
+    </div>
+
+    {#if loading}
+        <div class="flex items-center gap-2 text-sm text-sky-300">
+            <LoaderCircle class="inline h-5 w-5 animate-spin" /> Loading backups…
+        </div>
+    {:else if !backups.length}
+        <p class="text-sm text-slate-500">No backups found.</p>
+    {:else}
+        <div
+            class="overflow-x-auto rounded-md border border-slate-800 bg-slate-900/60 shadow-sm backdrop-blur-sm"
+        >
+            <table class="w-full text-sm">
+                <thead
+                    class="bg-slate-800/60 text-left text-[11px] tracking-wide text-slate-400 uppercase"
+                >
+                    <tr>
+                        <th class="px-3 py-2 font-medium">Filename</th>
+                        <th class="px-3 py-2 font-medium">Created</th>
+                        <th class="px-3 py-2 font-medium">Age</th>
+                        <th class="px-3 py-2 font-medium">Size</th>
+                        <th class="px-3 py-2 font-medium">User</th>
+                        <th class="px-3 py-2 text-right font-medium">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-800/70">
+                    {#each backups as b (b.filename)}
+                        <tr class="transition hover:bg-slate-800/50">
+                            <td class="px-3 py-2 font-mono text-[11px] break-all"
+                                >{b.filename}</td
+                            >
+                            <td class="px-3 py-2"
+                                >{new Date(b.created_at).toLocaleString()}</td
+                            >
+                            <td class="px-3 py-2 text-slate-400"
+                                >{ageLabel(b.age_seconds)}</td
+                            >
+                            <td class="px-3 py-2 text-slate-400"
+                                >{humanBytes(b.size_bytes)}</td
+                            >
+                            <td class="px-3 py-2 text-slate-400">{b.user || "—"}</td>
+                            <td class="px-3 py-2">
+                                <div class="flex justify-end gap-2">
+                                    <button
+                                        class="inline-flex items-center gap-1 rounded-md border border-sky-600/60 bg-sky-600/30 px-2 py-1 text-[11px] font-medium text-sky-100 hover:bg-sky-600/40 disabled:opacity-50"
+                                        disabled={previewLoading &&
+                                            !previewCache[b.filename]}
+                                        onclick={() => openPreview(b.filename)}
+                                        title="Preview raw JSON"
+                                    >
+                                        {#if previewLoading && !previewCache[b.filename]}
+                                            <LoaderCircle
+                                                class="inline h-4 w-4 animate-spin"
+                                            />
+                                        {:else}
+                                            <Eye class="inline h-4 w-4" />
+                                        {/if}
+                                        <span>Preview</span>
+                                    </button>
+                                    <button
+                                        class="inline-flex items-center gap-1 rounded-md border border-emerald-600/60 bg-emerald-600/30 px-2 py-1 text-[11px] font-medium text-emerald-100 hover:bg-emerald-600/40 disabled:opacity-50"
+                                        disabled={restoring === b.filename}
+                                        onclick={() => doRestore(b.filename)}
+                                        title="Restore backup"
+                                    >
+                                        {#if restoring === b.filename}
+                                            <LoaderCircle
+                                                class="inline h-4 w-4 animate-spin"
+                                            />
+                                        {:else}
+                                            <ArchiveRestore class="inline h-4 w-4" />
+                                        {/if}
+                                        <span>Restore</span>
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        </div>
+    {/if}
+
+    {#if previewing}
+        <div
+            class="fixed inset-0 z-40 flex items-start justify-center overflow-auto bg-black/70 p-4 py-10 backdrop-blur-sm"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Backup JSON Preview"
+            tabindex="-1"
+            onclick={(e) => e.target === e.currentTarget && closePreview()}
+            onkeydown={(e) => e.key === "Escape" && closePreview()}
+        >
+            <div
+                class="relative w-full max-w-3xl overflow-hidden rounded-md border border-slate-800 bg-slate-950/80 shadow-xl backdrop-blur-md"
+            >
+                <div
+                    class="flex items-center justify-between gap-4 border-b border-slate-800/80 bg-slate-900/60 px-4 py-2"
+                >
+                    <h3 class="text-sm font-semibold tracking-wide text-slate-200">
+                        Backup Preview <span
+                            class="ml-1 font-mono text-[10px] text-slate-400"
+                            >{previewing}</span
+                        >
+                    </h3>
+                    <button
+                        onclick={closePreview}
+                        class="rounded-md px-2 py-1 text-xs text-slate-400 hover:bg-slate-800/70 hover:text-slate-200"
+                        title="Close">✕</button
+                    >
+                </div>
+                <div
+                    class="max-h-[70vh] overflow-auto p-4 font-mono text-[11px] leading-snug"
+                >
+                    <code
+                        class="block rounded-md border border-slate-800 bg-slate-900/70 p-3 whitespace-pre-wrap"
+                    >
+                        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                        {@html highlightJson(previewCache[previewing] || {})}
+                    </code>
+                </div>
+                <div
+                    class="flex items-center justify-end gap-2 border-t border-slate-800/70 bg-slate-900/60 px-4 py-2"
+                >
+                    <button
+                        class="rounded-md border border-slate-600/60 bg-slate-700/40 px-3 py-1 text-[11px] font-medium text-slate-200 hover:bg-slate-600/50"
+                        onclick={closePreview}>Close</button
+                    >
+                </div>
+            </div>
+        </div>
+    {/if}
+</div>

--- a/src/models/db/sync_history.py
+++ b/src/models/db/sync_history.py
@@ -70,6 +70,7 @@ class SyncOutcome(StrEnum):
     NOT_FOUND = "not_found"  # No matching AniList entry could be found
     DELETED = "deleted"  # Item was deleted from AniList (destructive sync)
     PENDING = "pending"  # Item was identified for processing but not yet processed
+    UNDONE = "undone"  # Resulting entry produced by an explicit user undo action
 
 
 class SyncHistory(Base):

--- a/src/web/routes/api/__init__.py
+++ b/src/web/routes/api/__init__.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter
 
+from src.web.routes.api.backups import router as backups_router
 from src.web.routes.api.history import router as history_router
 from src.web.routes.api.logs import router as logs_history_router
 from src.web.routes.api.mappings import router as mappings_router
@@ -15,6 +16,7 @@ router = APIRouter()
 
 
 router.include_router(history_router, prefix="/history", tags=["history"])
+router.include_router(backups_router, prefix="/backups", tags=["backups"])
 router.include_router(mappings_router, prefix="/mappings", tags=["mappings"])
 router.include_router(logs_history_router, prefix="/logs", tags=["logs"])
 router.include_router(status_router, prefix="/status", tags=["status"])

--- a/src/web/routes/api/backups.py
+++ b/src/web/routes/api/backups.py
@@ -1,0 +1,75 @@
+"""Backup API endpoints."""
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from src.web.services.backup_service import (
+    BackupMeta,
+    RestoreSummary,
+    backup_service,
+)
+
+router = APIRouter()
+
+
+class ListBackupsResponse(BaseModel):
+    """Response model for listing backups."""
+
+    backups: list[BackupMeta]
+
+
+class RestoreRequest(BaseModel):
+    """Request body for triggering a restore."""
+
+    filename: str
+
+
+@router.get("/{profile}", response_model=ListBackupsResponse)
+def list_backups(profile: str) -> ListBackupsResponse:
+    """List backups for a profile.
+
+    Args:
+        profile (str): Profile name
+
+    Returns:
+        ListBackupsResponse: List of available backups
+    """
+    try:
+        backups = backup_service.list_backups(profile)
+        return ListBackupsResponse(backups=backups)
+    except ValueError as e:
+        raise HTTPException(400, str(e)) from e
+
+
+@router.post("/{profile}/restore", response_model=RestoreSummary)
+async def restore_backup(profile: str, req: RestoreRequest) -> RestoreSummary:
+    """Restore a backup file (no dry-run mode)."""
+    try:
+        return await backup_service.restore_backup(
+            profile=profile,
+            filename=req.filename,
+        )
+    except FileNotFoundError as e:
+        raise HTTPException(404, str(e)) from e
+    except ValueError as e:
+        raise HTTPException(400, str(e)) from e
+    except Exception as e:
+        raise HTTPException(500, f"Restore failed: {e}") from e
+
+
+@router.get("/{profile}/raw/{filename}")
+def get_backup_raw(profile: str, filename: str) -> dict[str, Any]:
+    """Return raw JSON content of a backup.
+
+    The response is unvalidated JSON so the UI can present a preview.
+    """
+    try:
+        return backup_service.read_backup_raw(profile, filename)
+    except FileNotFoundError as e:
+        raise HTTPException(404, str(e)) from e
+    except ValueError as e:
+        raise HTTPException(400, str(e)) from e
+    except Exception as e:
+        raise HTTPException(500, f"Failed to read backup: {e}") from e

--- a/src/web/routes/api/history.py
+++ b/src/web/routes/api/history.py
@@ -26,6 +26,12 @@ class OkResponse(BaseModel):
     ok: bool = True
 
 
+class UndoResponse(BaseModel):
+    """Response model for undo operation."""
+
+    item: ServiceHistoryItem
+
+
 @router.get("/{profile}", response_model=GetHistoryResponse)
 async def get_history(
     profile: str,
@@ -72,3 +78,15 @@ async def delete_history(profile: str, item_id: int) -> OkResponse:
     except ValueError as e:
         raise HTTPException(404, str(e)) from e
     return OkResponse()
+
+
+@router.post("/{profile}/{item_id}/undo", response_model=UndoResponse)
+async def undo_history(profile: str, item_id: int) -> UndoResponse:
+    """Undo a history item if possible."""
+    try:
+        item = await history_service.undo_item(profile, item_id)
+        return UndoResponse(item=item)
+    except ValueError as e:
+        raise HTTPException(404, str(e)) from e
+    except Exception as e:  # pragma: no cover
+        raise HTTPException(500, f"Undo failed: {e}") from e

--- a/src/web/services/backup_service.py
+++ b/src/web/services/backup_service.py
@@ -1,0 +1,198 @@
+"""Backup listing and restore service."""
+
+import contextlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+from pydantic import BaseModel
+
+from src.models.schemas.anilist import MediaList
+from src.web.state import app_state
+
+
+class BackupMeta(BaseModel):
+    """Metadata about a backup file used for listing in the UI."""
+
+    filename: str
+    created_at: datetime
+    size_bytes: int
+    entries: int | None = None
+    user: str | None = None
+    age_seconds: float
+
+
+class RestoreSummary(BaseModel):
+    """Result of a restore operation."""
+
+    ok: bool
+    filename: str
+    total_entries: int
+    processed: int
+    restored: int
+    skipped: int
+    errors: list[dict[str, Any]]
+    elapsed_seconds: float
+
+
+@dataclass
+class _ParsedBackup:
+    entries: list[MediaList]
+    user: str | None
+
+
+class BackupService:
+    """Service for listing and restoring AniList backups."""
+
+    def _get_profile_bridge(self, profile: str):
+        """Get the scheduler bridge client for a profile."""
+        if not app_state.scheduler:
+            raise ValueError("Scheduler not initialised")
+        bridge = app_state.scheduler.bridge_clients.get(profile)
+        if not bridge:
+            raise ValueError(f"Unknown profile: {profile}")
+        return bridge
+
+    def _backup_dir(self, profile: str) -> Path:
+        """Get the backup directory for a profile."""
+        bridge = self._get_profile_bridge(profile)
+        return bridge.profile_config.data_path / "backups"
+
+    def list_backups(self, profile: str) -> list[BackupMeta]:
+        """Enumerate available backups for a profile.
+
+        Args:
+            profile: Profile name.
+
+        Returns:
+            list[BackupMeta]: List of backup metadata, newest first.
+        """
+        bdir = self._backup_dir(profile)
+        if not bdir.exists():
+            return []
+        metas: list[BackupMeta] = []
+        now = datetime.now(UTC)
+        for f in sorted(bdir.glob("plexanibridge-*.json")):
+            try:
+                parts = f.name.split(".")
+                ts_raw = parts[-2] if len(parts) >= 2 else None
+                dt: datetime | None = None
+                if ts_raw and ts_raw.isdigit():
+                    try:
+                        dt = datetime.strptime(ts_raw, "%Y%m%d%H%M%S").replace(
+                            tzinfo=UTC
+                        )
+                    except ValueError:
+                        dt = datetime.fromtimestamp(f.stat().st_mtime, UTC)
+                else:
+                    dt = datetime.fromtimestamp(f.stat().st_mtime, UTC)
+                metas.append(
+                    BackupMeta(
+                        filename=f.name,
+                        created_at=dt,
+                        size_bytes=f.stat().st_size,
+                        entries=None,  # Can be populated on demand
+                        user=(
+                            f.name.split("-")[1].split(".")[0]
+                            if "-" in f.name
+                            else None
+                        ),
+                        age_seconds=(now - dt).total_seconds(),
+                    )
+                )
+            except Exception:
+                continue
+        return list(reversed(metas))  # Newest first
+
+    def read_backup_raw(self, profile: str, filename: str) -> dict[str, Any]:
+        """Return the raw JSON content of a backup file.
+
+        Args:
+            profile: Profile name
+            filename: Backup filename (basename only)
+
+        Returns:
+            dict[str, Any]: Parsed JSON content.
+        """
+        bdir = self._backup_dir(profile)
+        path = (bdir / filename).resolve()
+        if path.parent != bdir.resolve():  # Path traversal protection
+            raise ValueError("Invalid backup filename")
+        if not path.exists():
+            raise FileNotFoundError("Backup file not found")
+
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+    def _parse_backup(self, profile: str, filename: str) -> _ParsedBackup:
+        """Parse a backup file and return its entries."""
+        bdir = self._backup_dir(profile)
+        path = (bdir / filename).resolve()
+
+        if path.parent != bdir.resolve():
+            raise ValueError("Invalid backup filename")
+        if not path.exists():
+            raise FileNotFoundError("Backup file not found")
+
+        raw = json.loads(path.read_text())
+        user = None
+
+        with contextlib.suppress(Exception):
+            user = raw.get("user", {}).get("name")
+        entries: list[MediaList] = []
+
+        for lst in raw.get("lists", []) or []:
+            if lst.get("isCustomList"):
+                continue
+            for entry in lst.get("entries", []) or []:
+                try:
+                    entries.append(MediaList(**entry))
+                except Exception:
+                    continue
+        return _ParsedBackup(entries=entries, user=user)
+
+    async def restore_backup(self, profile: str, filename: str) -> RestoreSummary:
+        """Restore a backup file for a profile.
+
+        Args:
+            profile: Profile name
+            filename: Backup filename (basename only)
+        """
+        bridge = self._get_profile_bridge(profile)
+        parsed = self._parse_backup(profile, filename)
+        total = len(parsed.entries)
+        start = perf_counter()
+        errors: list[dict[str, Any]] = []
+
+        BATCH = 50
+        restored = 0
+        for i in range(0, total, BATCH):
+            batch = parsed.entries[i : i + BATCH]
+            try:
+                await bridge.anilist_client.batch_update_anime_entries(batch)
+                restored += len(batch)
+            except Exception as e:
+                errors.append(
+                    {
+                        "index_start": i,
+                        "count": len(batch),
+                        "error": str(e),
+                    }
+                )
+
+        return RestoreSummary(
+            ok=not errors,
+            filename=filename,
+            total_entries=total,
+            processed=total,
+            restored=restored,
+            skipped=0,
+            errors=errors,
+            elapsed_seconds=perf_counter() - start,
+        )
+
+
+backup_service = BackupService()


### PR DESCRIPTION
### Description

This PR adds the ability for users to restore from their daily AniList backups directly from the web UI.

It also introduces an undo button on the profile timeline page, allowing users to undo specific syncs.

**What's new:**

- Backup view and restore page
- Undo button for syncs on the timeline page

### Issues Fixed or Closed by this PR

- Closes #153 

### Checklist

- [x] I have performed a self-review of my own code
- [x] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes to the documentation in `docs/` if applicable
