### PR TITLE
Upstream mappings URL config option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ PAB_PLEX_URL=...
 #== Global Settings ==#
 # PAB_DATA_PATH="./data"
 # PAB_LOG_LEVEL="INFO"
+# PAB_MAPPINGS_URL="https://raw.githubusercontent.com/eliasbenb/PlexAniBridge-Mappings/v2/mappings.json"
 # PAB_WEB_ENABLED=true
 # PAB_WEB_HOST="0.0.0.0"
 # PAB_WEB_PORT=4848

--- a/data/config.example.yaml
+++ b/data/config.example.yaml
@@ -23,6 +23,7 @@ plex_url: ...
 #== Global Settings ==#
 # data_path: "./data"
 # log_level: "INFO"
+# mappings_url: "https://raw.githubusercontent.com/eliasbenb/PlexAniBridge-Mappings/v2/mappings.json"
 # web_enabled: true
 # web_host: "0.0.0.0"
 # web_port: 4848

--- a/docs/compose.yaml
+++ b/docs/compose.yaml
@@ -24,6 +24,7 @@ services:
             # PAB_PROFILES__example__$FIELD=$VALUE
             # PAB_DATA_PATH: /config
             # PAB_LOG_LEVEL: INFO
+            # PAB_MAPPINGS_URL=https://raw.githubusercontent.com/eliasbenb/PlexAniBridge-Mappings/v2/mappings.json
             # PAB_WEB_ENABLED: True
             # PAB_WEB_HOST: 0.0.0.0
             # PAB_WEB_PORT: 4848

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -317,6 +317,24 @@ Sets logging verbosity for the entire application.
 
 ---
 
+### `PAB_MAPPINGS_URL`
+
+`str` (Optional, default: `https://raw.githubusercontent.com/eliasbenb/PlexAniBridge-Mappings/v2/mappings.json`)
+
+URL to the upstream mappings source. This can be a JSON or YAML file.
+
+This option is only intended for advanced users who want to use their own upstream mappings source or disable upstream mappings entirely. For most users, it is recommended to keep the default value.
+
+!!! note "Custom Mappings"
+
+    This setting works in tandem with custom mappings stored in the `mappings/` directory inside the data path. Custom mappings will override any upstream mappings.
+
+??? tip "Disabling Upstream Mappings"
+
+    To disable upstream mappings, set this to an empty string: `""`.
+
+---
+
 ### `PAB_WEB_ENABLED`
 
 `bool` (Optional, default: `True`)

--- a/src/core/animap.py
+++ b/src/core/animap.py
@@ -34,15 +34,18 @@ class AniMapClient:
         https://github.com/eliasbenb/PlexAniBridge-Mappings
     """
 
-    def __init__(self, data_path: Path) -> None:
+    def __init__(self, data_path: Path, upstream_url: str | None) -> None:
         """Initializes the AniMapClient.
 
         Args:
             data_path (Path): Path to the data directory for storing mappings and cache
                               files.
+            upstream_url (str | None): URL to the upstream mappings source JSON or YAML
+                                    file. If None, no upstream mappings will be used.
         """
-        self.mappings_client = MappingsClient(data_path)
         self.data_path = data_path
+        self.upstream_url = upstream_url
+        self.mappings_client = MappingsClient(data_path, upstream_url)
 
     async def initialize(self) -> None:
         """Initialize the client by syncing the database.

--- a/src/core/sched.py
+++ b/src/core/sched.py
@@ -197,7 +197,9 @@ class SchedulerClient:
             global_config: Global application configuration
         """
         self.global_config = global_config
-        self.shared_animap_client = AniMapClient(global_config.data_path)
+        self.shared_animap_client = AniMapClient(
+            global_config.data_path, global_config.mappings_url
+        )
         self.bridge_clients: dict[str, BridgeClient] = {}
         self.profile_schedulers: dict[str, ProfileScheduler] = {}
         self.stop_event = asyncio.Event()


### PR DESCRIPTION
### Description

This PR adds a new config option `MAPPINGS_URL` that allows users to customize the upstream mappings source.

_Note: this option works in tandem with the custom mappings file and is only intended for advanced users who maintain their own mappings repository or want to completely disable pulling from an upstream mappings repo_

**What's new:**

- `MAPPINGS_URL` config option that takes a string URL (or None)

### Issues Fixed or Closed by this PR

- Closes #157 

### Checklist

- [x] I have performed a self-review of my own code
- [x] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes to the documentation in `docs/` if applicable
