### PR TITLE
AniList mappings title search

### DIFF
--- a/frontend/src/lib/ui/ui-tooltip.svelte
+++ b/frontend/src/lib/ui/ui-tooltip.svelte
@@ -1,19 +1,20 @@
 <script lang="ts">
-  import { Tooltip } from "bits-ui";
-  export let delay = 100;
-  export let contentClass =
-    "z-20 w-min min-w-[8rem] rounded-md border border-slate-800/70 bg-slate-900/95 p-2 shadow-xl";
-  export let sideOffset = 8;
+    import { Tooltip } from "bits-ui";
+
+    export let delay = 100;
+    export let contentClass =
+        "z-20 w-min min-w-[8rem] rounded-md border border-slate-800/70 bg-slate-900/95 p-2 shadow-xl";
+    export let sideOffset = 8;
 </script>
 
 <Tooltip.Root delayDuration={delay}>
-  <Tooltip.Trigger>
-    <slot name="trigger" />
-  </Tooltip.Trigger>
-  <Tooltip.Portal>
-    <Tooltip.Content sideOffset={sideOffset} class={contentClass}>
-      <slot />
-      <Tooltip.Arrow />
-    </Tooltip.Content>
-  </Tooltip.Portal>
+    <Tooltip.Trigger>
+        <slot name="trigger" />
+    </Tooltip.Trigger>
+    <Tooltip.Portal>
+        <Tooltip.Content {sideOffset} class={contentClass}>
+            <slot />
+            <Tooltip.Arrow />
+        </Tooltip.Content>
+    </Tooltip.Portal>
 </Tooltip.Root>

--- a/frontend/src/routes/mappings/+page.svelte
+++ b/frontend/src/routes/mappings/+page.svelte
@@ -101,6 +101,18 @@
         };
     }
 
+    function isIdLike(q: string): boolean {
+        const s = (q || "").trim();
+        if (!s) return false;
+        // Pure digits (AniList, AniDB, TVDB, TMDB, MAL IDs)
+        if (/^\d+$/.test(s)) return true;
+        // IMDB IDs like tt12345678
+        if (/^tt\d+$/i.test(s)) return true;
+        // Allow simple TV season key like s1, s01 (tvdb_mappings keys)
+        if (/^s\d+$/i.test(s)) return true;
+        return false;
+    }
+
     async function load() {
         loading = true;
         try {
@@ -108,7 +120,10 @@
                 page: String(page),
                 per_page: String(perPage),
             });
-            if (query) p.set("search", query);
+            if (query) {
+                if (isIdLike(query)) p.set("id_search", query);
+                else p.set("title_search", query);
+            }
             if (customOnly) p.set("custom_only", "true");
             p.set("with_anilist", "true");
             const r = await apiFetch("/api/mappings?" + p.toString());

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -71,6 +71,19 @@ class UnsupportedMediaTypeError(MediaTypeError, ValueError):
     status_code = 400
 
 
+# AniList client errors
+class AniListError(PlexAniBridgeError):
+    """Base class for AniList-related failures."""
+
+    status_code = 500
+
+
+class AniListTokenRequiredError(AniListError, RuntimeError):
+    """Operation requires an authenticated AniList client (token)."""
+
+    status_code = 401
+
+
 # Plex client errors
 class PlexError(PlexAniBridgeError):
     """Base class for Plex-related failures."""

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -101,6 +101,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
             await scheduler.start()
             log.success("Web: Scheduler started for web UI")
 
+    try:
+        await get_app_state().ensure_public_anilist()
+    except Exception:
+        log.debug("Web: Failed to initialize public AniList client at startup")
+
     root_logger = log
     log_ws_handler = get_log_ws_handler()
     if log_ws_handler not in root_logger.handlers:

--- a/src/web/services/mappings_service.py
+++ b/src/web/services/mappings_service.py
@@ -414,11 +414,7 @@ class MappingsService:
                 search_limit = min(max(per_page * 5, 50), 200)
                 api_ids: set[int] = set()
                 async for m in anilist_client.search_anime(
-                    title_search, is_movie=False, episodes=None, limit=search_limit
-                ):
-                    api_ids.add(int(m.id))
-                async for m in anilist_client.search_anime(
-                    title_search, is_movie=True, episodes=None, limit=search_limit
+                    title_search, is_movie=None, episodes=None, limit=search_limit
                 ):
                     api_ids.add(int(m.id))
 


### PR DESCRIPTION
### Description

This PR introduces the ability to do title searches on the mappings table view. This involves searching the AniList API and joining the results with what exists in the local mappings database.

_Note: the frontend will infer what type of search you want to do based on your query's format. E.g. pure integer queries will do the legacy, local ID search_

**What's new:**

- Title search that interacts with the AniList API on the mappings UI
- Introduced the ability to create 'public' AniList clients on the backend

**Improvements:**

- Make use of the public AniList client when enriching results instead of a random AniList token from one of the profiles

### Issues Fixed or Closed by this PR

- Closes #166 

### Checklist

- [x] I have performed a self-review of my own code
- [x] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes to the documentation in `docs/` if applicable
