### PR TITLE
Mapping query URL params and navigation

### DIFF
--- a/frontend/src/lib/components/mappings/mappings-table.svelte
+++ b/frontend/src/lib/components/mappings/mappings-table.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { ExternalLink } from "@lucide/svelte";
     import { Popover, Tooltip } from "bits-ui";
 
     import type { Mapping } from "$lib/types/api";
@@ -11,6 +12,7 @@
         columns?: ColumnConfig[];
         onEdit?: (payload: { mapping: Mapping }) => void;
         onDelete?: (payload: { mapping: Mapping; kind: "custom" | "full" }) => void;
+        onNavigateToQuery?: (payload: { query: string }) => void;
     }
 
     let {
@@ -18,6 +20,7 @@
         columns = $bindable([]),
         onEdit,
         onDelete,
+        onNavigateToQuery,
     }: Props = $props();
 
     if (!columns.length) {
@@ -60,6 +63,13 @@
     }
 
     const visibleColumns = $derived(columns.filter((c) => c.visible));
+
+    function navigate(prefix: string, value: string | number | null | undefined) {
+        if (value === null || value === undefined) return;
+        const text = String(value).trim();
+        if (!text) return;
+        onNavigateToQuery?.({ query: `${prefix}:${text}` });
+    }
 </script>
 
 <svelte:window
@@ -183,98 +193,204 @@
                                         </div>
                                     </div>
                                 {:else if column.id === "anilist"}
-                                    <div class="truncate font-mono">
-                                        {#if m.anilist_id}<a
-                                                rel="noopener"
-                                                target="_blank"
-                                                class="block truncate text-emerald-400 hover:underline"
-                                                title={m.anilist_id.toString()}
-                                                href={"https://anilist.co/anime/" +
-                                                    m.anilist_id}>{m.anilist_id}</a
-                                            >{:else}-{/if}
-                                    </div>
-                                {:else if column.id === "anidb"}
-                                    <div class="truncate font-mono">
-                                        {#if m.anidb_id}<a
-                                                rel="noopener"
-                                                target="_blank"
-                                                class="block truncate text-emerald-400 hover:underline"
-                                                title={m.anidb_id.toString()}
-                                                href={"https://anidb.net/anime/" +
-                                                    m.anidb_id}>{m.anidb_id}</a
-                                            >{:else}-{/if}
-                                    </div>
-                                {:else if column.id === "imdb"}
-                                    <div class="truncate font-mono">
-                                        {#if m.imdb_id && m.imdb_id.length}
-                                            <div
-                                                class="truncate"
-                                                title={m.imdb_id.join(", ")}>
-                                                {#each m.imdb_id as imdb, i (imdb)}<a
+                                    <div class="font-mono">
+                                        {#if m.anilist_id}
+                                            <div class="scroll-wrapper">
+                                                <div class="scroll-row">
+                                                    <button
+                                                        type="button"
+                                                        class="cursor-pointer rounded px-0.5 text-left text-emerald-400 select-text hover:underline focus:ring-1 focus:ring-emerald-500/40 focus:outline-none"
+                                                        title={`Filter by AniList ${m.anilist_id}`}
+                                                        onclick={() =>
+                                                            navigate(
+                                                                "anilist",
+                                                                m.anilist_id,
+                                                            )}>{m.anilist_id}</button>
+                                                    <a
                                                         rel="noopener"
                                                         target="_blank"
-                                                        class="text-emerald-400 hover:underline"
-                                                        href={"https://www.imdb.com/title/" +
-                                                            imdb +
-                                                            "/"}>{imdb}</a
-                                                    >{#if m.imdb_id && i < m.imdb_id.length - 1},
-                                                    {/if}{/each}
+                                                        class="text-slate-500 transition-colors hover:text-emerald-300"
+                                                        aria-label={`Open AniList ${m.anilist_id}`}
+                                                        href={`https://anilist.co/anime/${m.anilist_id}`}>
+                                                        <ExternalLink class="h-3 w-3" />
+                                                    </a>
+                                                </div>
+                                            </div>
+                                        {:else}-{/if}
+                                    </div>
+                                {:else if column.id === "anidb"}
+                                    <div class="font-mono">
+                                        {#if m.anidb_id}
+                                            <div class="scroll-wrapper">
+                                                <div class="scroll-row">
+                                                    <button
+                                                        type="button"
+                                                        class="cursor-pointer rounded px-0.5 text-left text-emerald-400 select-text hover:underline focus:ring-1 focus:ring-emerald-500/40 focus:outline-none"
+                                                        title={`Filter by AniDB ${m.anidb_id}`}
+                                                        onclick={() =>
+                                                            navigate(
+                                                                "anidb",
+                                                                m.anidb_id,
+                                                            )}>{m.anidb_id}</button>
+                                                    <a
+                                                        rel="noopener"
+                                                        target="_blank"
+                                                        class="text-slate-500 transition-colors hover:text-emerald-300"
+                                                        aria-label={`Open AniDB ${m.anidb_id}`}
+                                                        href={`https://anidb.net/anime/${m.anidb_id}`}>
+                                                        <ExternalLink class="h-3 w-3" />
+                                                    </a>
+                                                </div>
+                                            </div>
+                                        {:else}-{/if}
+                                    </div>
+                                {:else if column.id === "imdb"}
+                                    <div class="font-mono">
+                                        {#if m.imdb_id && m.imdb_id.length}
+                                            <div class="scroll-wrapper">
+                                                <div
+                                                    class="scroll-row"
+                                                    title={m.imdb_id.join(", ")}>
+                                                    {#each m.imdb_id as imdb (imdb)}
+                                                        <div
+                                                            class="flex shrink-0 items-center gap-1">
+                                                            <button
+                                                                type="button"
+                                                                class="cursor-pointer rounded px-0.5 text-left text-emerald-400 select-text hover:underline focus:ring-1 focus:ring-emerald-500/40 focus:outline-none"
+                                                                title={`Filter by IMDb ${imdb}`}
+                                                                onclick={() =>
+                                                                    navigate(
+                                                                        "imdb",
+                                                                        imdb,
+                                                                    )}>{imdb}</button>
+                                                            <a
+                                                                rel="noopener"
+                                                                target="_blank"
+                                                                class="text-slate-500 transition-colors hover:text-emerald-300"
+                                                                aria-label={`Open IMDb ${imdb}`}
+                                                                href={`https://www.imdb.com/title/${imdb}/`}>
+                                                                <ExternalLink
+                                                                    class="h-3 w-3" />
+                                                            </a>
+                                                        </div>
+                                                    {/each}
+                                                </div>
                                             </div>
                                         {:else}-{/if}
                                     </div>
                                 {:else if column.id === "tmdb_movie"}
-                                    <div class="truncate font-mono">
+                                    <div class="font-mono">
                                         {#if m.tmdb_movie_id && m.tmdb_movie_id.length}
-                                            <div
-                                                class="truncate"
-                                                title={m.tmdb_movie_id.join(", ")}>
-                                                {#each m.tmdb_movie_id as id, i (id)}<a
-                                                        rel="noopener"
-                                                        target="_blank"
-                                                        class="text-emerald-400 hover:underline"
-                                                        href={"https://www.themoviedb.org/movie/" +
-                                                            id}>{id}</a
-                                                    >{#if m.tmdb_movie_id && i < m.tmdb_movie_id.length - 1},
-                                                    {/if}{/each}
+                                            <div class="scroll-wrapper">
+                                                <div
+                                                    class="scroll-row"
+                                                    title={m.tmdb_movie_id.join(", ")}>
+                                                    {#each m.tmdb_movie_id as id (id)}
+                                                        <div
+                                                            class="flex shrink-0 items-center gap-1">
+                                                            <button
+                                                                type="button"
+                                                                class="cursor-pointer rounded px-0.5 text-left text-emerald-400 select-text hover:underline focus:ring-1 focus:ring-emerald-500/40 focus:outline-none"
+                                                                title={`Filter by TMDB Movie ${id}`}
+                                                                onclick={() =>
+                                                                    navigate(
+                                                                        "tmdb_movie",
+                                                                        id,
+                                                                    )}>{id}</button>
+                                                            <a
+                                                                rel="noopener"
+                                                                target="_blank"
+                                                                class="text-slate-500 transition-colors hover:text-emerald-300"
+                                                                aria-label={`Open TMDB Movie ${id}`}
+                                                                href={`https://www.themoviedb.org/movie/${id}`}>
+                                                                <ExternalLink
+                                                                    class="h-3 w-3" />
+                                                            </a>
+                                                        </div>
+                                                    {/each}
+                                                </div>
                                             </div>
                                         {:else}-{/if}
                                     </div>
                                 {:else if column.id === "tmdb_show"}
-                                    <div class="truncate font-mono">
-                                        {#if m.tmdb_show_id}<a
-                                                rel="noopener"
-                                                target="_blank"
-                                                class="block truncate text-emerald-400 hover:underline"
-                                                title={m.tmdb_show_id.toString()}
-                                                href={"https://www.themoviedb.org/tv/" +
-                                                    m.tmdb_show_id}>{m.tmdb_show_id}</a
-                                            >{:else}-{/if}
-                                    </div>
-                                {:else if column.id === "tvdb"}
-                                    <div class="truncate font-mono">
-                                        {#if m.tvdb_id}<a
-                                                rel="noopener"
-                                                target="_blank"
-                                                class="block truncate text-emerald-400 hover:underline"
-                                                title={m.tvdb_id.toString()}
-                                                href={"https://thetvdb.com/?tab=series&id=" +
-                                                    m.tvdb_id}>{m.tvdb_id}</a
-                                            >{:else}-{/if}
-                                    </div>
-                                {:else if column.id === "mal"}
-                                    <div class="truncate font-mono">
-                                        {#if m.mal_id && m.mal_id.length}
-                                            <div
-                                                class="truncate"
-                                                title={m.mal_id.join(", ")}>
-                                                {#each m.mal_id as id, i (id)}<a
+                                    <div class="font-mono">
+                                        {#if m.tmdb_show_id}
+                                            <div class="scroll-wrapper">
+                                                <div class="scroll-row">
+                                                    <button
+                                                        type="button"
+                                                        class="cursor-pointer rounded px-0.5 text-left text-emerald-400 select-text hover:underline focus:ring-1 focus:ring-emerald-500/40 focus:outline-none"
+                                                        title={`Filter by TMDB Show ${m.tmdb_show_id}`}
+                                                        onclick={() =>
+                                                            navigate(
+                                                                "tmdb_show",
+                                                                m.tmdb_show_id,
+                                                            )}>{m.tmdb_show_id}</button>
+                                                    <a
                                                         rel="noopener"
                                                         target="_blank"
-                                                        class="text-emerald-400 hover:underline"
-                                                        href={"https://myanimelist.net/anime/" +
-                                                            id}>{id}</a
-                                                    >{#if m.mal_id && i < m.mal_id.length - 1},
-                                                    {/if}{/each}
+                                                        class="text-slate-500 transition-colors hover:text-emerald-300"
+                                                        aria-label={`Open TMDB Show ${m.tmdb_show_id}`}
+                                                        href={`https://www.themoviedb.org/tv/${m.tmdb_show_id}`}>
+                                                        <ExternalLink class="h-3 w-3" />
+                                                    </a>
+                                                </div>
+                                            </div>
+                                        {:else}-{/if}
+                                    </div>
+                                {:else if column.id === "tvdb"}
+                                    <div class="font-mono">
+                                        {#if m.tvdb_id}
+                                            <div class="scroll-wrapper">
+                                                <div class="scroll-row">
+                                                    <button
+                                                        type="button"
+                                                        class="cursor-pointer rounded px-0.5 text-left text-emerald-400 select-text hover:underline focus:ring-1 focus:ring-emerald-500/40 focus:outline-none"
+                                                        title={`Filter by TVDB ${m.tvdb_id}`}
+                                                        onclick={() =>
+                                                            navigate("tvdb", m.tvdb_id)}
+                                                        >{m.tvdb_id}</button>
+                                                    <a
+                                                        rel="noopener"
+                                                        target="_blank"
+                                                        class="text-slate-500 transition-colors hover:text-emerald-300"
+                                                        aria-label={`Open TVDB ${m.tvdb_id}`}
+                                                        href={`https://thetvdb.com/?tab=series&id=${m.tvdb_id}`}>
+                                                        <ExternalLink class="h-3 w-3" />
+                                                    </a>
+                                                </div>
+                                            </div>
+                                        {:else}-{/if}
+                                    </div>
+                                {:else if column.id === "mal"}
+                                    <div class="font-mono">
+                                        {#if m.mal_id && m.mal_id.length}
+                                            <div class="scroll-wrapper">
+                                                <div
+                                                    class="scroll-row"
+                                                    title={m.mal_id.join(", ")}>
+                                                    {#each m.mal_id as id (id)}
+                                                        <div
+                                                            class="flex shrink-0 items-center gap-1">
+                                                            <button
+                                                                type="button"
+                                                                class="cursor-pointer rounded px-0.5 text-left text-emerald-400 select-text hover:underline focus:ring-1 focus:ring-emerald-500/40 focus:outline-none"
+                                                                title={`Filter by MAL ${id}`}
+                                                                onclick={() =>
+                                                                    navigate("mal", id)}
+                                                                >{id}</button>
+                                                            <a
+                                                                rel="noopener"
+                                                                target="_blank"
+                                                                class="text-slate-500 transition-colors hover:text-emerald-300"
+                                                                aria-label={`Open MAL ${id}`}
+                                                                href={`https://myanimelist.net/anime/${id}`}>
+                                                                <ExternalLink
+                                                                    class="h-3 w-3" />
+                                                            </a>
+                                                        </div>
+                                                    {/each}
+                                                </div>
                                             </div>
                                         {:else}-{/if}
                                     </div>
@@ -464,3 +580,44 @@
         </table>
     </div>
 </div>
+
+<style>
+    .scroll-wrapper {
+        position: relative;
+    }
+
+    .scroll-wrapper:hover::after,
+    .scroll-wrapper:focus-within::after {
+        opacity: 0.85;
+    }
+
+    .scroll-row {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        overflow-x: auto;
+        white-space: nowrap;
+        padding-bottom: 0.35rem;
+        padding-right: 0.75rem;
+        scrollbar-width: thin;
+        scrollbar-gutter: stable both-edges;
+    }
+
+    .scroll-row::-webkit-scrollbar {
+        height: 6px;
+    }
+
+    .scroll-row::-webkit-scrollbar-track {
+        background: rgba(71, 85, 105, 0.35);
+        border-radius: 9999px;
+    }
+
+    .scroll-row::-webkit-scrollbar-thumb {
+        background: rgba(16, 185, 129, 0.45);
+        border-radius: 9999px;
+    }
+
+    .scroll-row:hover::-webkit-scrollbar-thumb {
+        background: rgba(16, 185, 129, 0.8);
+    }
+</style>

--- a/frontend/src/lib/components/mappings/tool-bar.svelte
+++ b/frontend/src/lib/components/mappings/tool-bar.svelte
@@ -12,6 +12,7 @@
         loading?: boolean;
         onLoad: () => void;
         onCancel: () => void;
+        onSubmit?: () => void;
         onCreate?: () => void;
     }
 
@@ -24,6 +25,7 @@
         onLoad,
         onCancel,
         onCreate,
+        onSubmit,
     }: Props = $props();
 
     function toggleCustom() {
@@ -43,6 +45,7 @@
             {onCancel}
             onSubmit={() => {
                 page = 1;
+                onSubmit?.();
                 onLoad();
             }} />
     </div>
@@ -96,6 +99,7 @@
             {onCancel}
             onSubmit={() => {
                 page = 1;
+                onSubmit?.();
                 onLoad();
             }} />
     </div>

--- a/frontend/src/lib/components/timeline/timeline-item.svelte
+++ b/frontend/src/lib/components/timeline/timeline-item.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import {
         ExternalLink,
+        Hash,
         LoaderCircle,
         RefreshCcw,
         RotateCw,
@@ -8,8 +9,10 @@
         SquarePlus,
         Trash2,
     } from "@lucide/svelte";
+    import { SvelteURLSearchParams } from "svelte/reactivity";
     import { fade } from "svelte/transition";
 
+    import { resolve } from "$app/paths";
     import TimelineDiffViewer from "$lib/components/timeline/timeline-diff-viewer.svelte";
     import TimelineManagePins from "$lib/components/timeline/timeline-manage-pins.svelte";
     import type { ItemDiffUi, OutcomeMeta } from "$lib/components/timeline/types";
@@ -76,6 +79,19 @@
         onPinsSaved,
         onPinsBusy,
     }: Props = $props();
+
+    function mappingUrl(item: HistoryItem): string | null {
+        if (item.anilist?.id) {
+            return (
+                resolve("/mappings") +
+                "?" +
+                new SvelteURLSearchParams({
+                    q: `anilist:${item.anilist.id.toString()}`,
+                }).toString()
+            );
+        }
+        return null;
+    }
 
     const coverHref = anilistUrl(item);
 
@@ -144,7 +160,7 @@
                     </div>
                     <div
                         class="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-400">
-                        {#if item.anilist?.id}
+                        {#if anilistUrl(item)}
                             <!-- eslint-disable svelte/no-navigation-without-resolve -->
                             <a
                                 href={anilistUrl(item)!}
@@ -158,7 +174,7 @@
                             <!-- eslint-enable svelte/no-navigation-without-resolve -->
                         {/if}
 
-                        {#if item.plex_guid}
+                        {#if plexUrl(item)}
                             <!-- eslint-disable svelte/no-navigation-without-resolve -->
                             <a
                                 href={plexUrl(item)!}
@@ -171,6 +187,19 @@
                             </a>
                             <!-- eslint-enable svelte/no-navigation-without-resolve -->
                         {/if}
+
+                        {#if mappingUrl(item)}
+                            <!-- eslint-disable svelte/no-navigation-without-resolve -->
+                            <a
+                                href={mappingUrl(item)!}
+                                class="inline-flex items-center gap-1 rounded-md border border-slate-600/60 bg-slate-700/50 px-1 py-0.5 text-[9px] font-semibold text-slate-100 hover:bg-slate-600/60"
+                                title="View mapping">
+                                <Hash class="inline h-3.5 w-3.5 text-[11px]" />
+                                Mapping
+                            </a>
+                            <!-- eslint-enable svelte/no-navigation-without-resolve -->
+                        {/if}
+
                         <span class="text-xs text-slate-400">
                             {new Date(item.timestamp + "Z").toLocaleString()}
                         </span>

--- a/frontend/src/routes/mappings/+page.svelte
+++ b/frontend/src/routes/mappings/+page.svelte
@@ -342,7 +342,8 @@
             {items}
             bind:columns
             onEdit={handleEdit}
-            onDelete={handleDelete} />
+            onDelete={handleDelete}
+            onNavigateToQuery={({ query: next }) => navigateToQuery(next)} />
     </div>
     <Pagination
         class="mt-3"

--- a/frontend/src/routes/mappings/+page.svelte
+++ b/frontend/src/routes/mappings/+page.svelte
@@ -102,6 +102,7 @@
             }
         }
     }
+
     async function navigateToQuery(nextQuery: string) {
         const value = nextQuery.trim();
         if (!value) return;
@@ -111,6 +112,9 @@
         await load();
     }
 
+    function handleSearchSubmit() {
+        queuePushState();
+    }
 
     function cancelLoad() {
         if (!currentAbort) return;
@@ -250,7 +254,8 @@
             {loading}
             onLoad={load}
             onCancel={cancelLoad}
-            onCreate={openCreateEditor} />
+            onCreate={openCreateEditor}
+            onSubmit={handleSearchSubmit} />
     </div>
     <div
         class="relative flex h-[70vh] flex-col overflow-hidden rounded-md border border-slate-800/70 bg-slate-900/40 backdrop-blur-sm">


### PR DESCRIPTION
### Description

This PR allows loading and writing queries from the mapping page's URL params. For example, navigating to `/mappings?q=anilist:1` will now search for mappings with anilist_id=1 on load.

This was done in order to make in-app mapping navigation easier. Users can now click on ID columns to filter their searches by that ID. This is also available cross-page in the timeline view.

**What's new:**

- Sync mapping searches with the `/mappings` query string.
- Make AniList, AniDB, IMDb, TMDB, TVDB, and MAL columns interactive with inline "filter" buttons plus external links.
- Add a "Mapping" badge to timeline cards that opens the mappings page pre-filtered to the item's AniList ID.

**Improvements:**

- Tweak scroll styling for multi-value ID columns to keep long lists on one line and scrollable


### Checklist

- [x] I have performed a self-review of my own code
- [x] My code passes the test suite (`pytest`)
- [x] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes to the documentation in `docs/` if applicable
