### PR TITLE
Zstandard compressed mappings loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "requests>=2.32.5",
     "ruamel-yaml>=0.18.16",
     "sqlalchemy>=2.0.45",
+    "zstandard>=0.25.0",
 ]
 
 [project.scripts]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -273,9 +273,10 @@ class AniBridgeConfig(BaseSettings):
         default=LogLevel.INFO, description="Logging level for the application"
     )
     mappings_url: str | None = Field(
-        default="https://raw.githubusercontent.com/anibridge/anibridge-mappings-staging/v3/mappings.json",
+        default="https://github.com/anibridge/anibridge-mappings/releases/latest/download/mappings.json.zst",
         description=(
             "URL to JSON or YAML file to use as the upstream mappings source. "
+            "Additionally accepts Zstandard compressed (.zst) files. "
             "If not set, no upstream mappings will be used."
         ),
     )

--- a/src/core/animap.py
+++ b/src/core/animap.py
@@ -402,7 +402,7 @@ class AnimapClient:
         mappings = await self.mappings_client.load_mappings()
         provenance_by_descriptor = self.mappings_client.get_provenance()
 
-        descriptors, edges, provenance, invalid_count = self._build_edges(
+        descriptors, edges, provenance, _invalid_count = self._build_edges(
             mappings, provenance_by_descriptor
         )
         edge_list = tuple(edges.values())
@@ -573,10 +573,21 @@ class AnimapClient:
 
             self._build_cache_from_edges(edge_list, curr_mappings_hash)
 
+            existing_pairs = {
+                (src_id, dst_id) for src_id, dst_id, _, _ in existing_keys
+            }
+            new_pairs = {(src_id, dst_id) for src_id, dst_id, _, _ in new_keys}
+            removed_pairs = existing_pairs - new_pairs
+            created_pairs = new_pairs - existing_pairs
+            changed_pairs = {
+                (src_id, dst_id)
+                for src_id, dst_id, _, _ in (to_delete_mappings | to_insert_mappings)
+            }
+            updated_pairs = changed_pairs - removed_pairs - created_pairs
+
             log.success(
-                "Database sync complete: "
-                f"{len(to_delete_entries)} entries removed, "
-                f"{len(to_delete_mappings)} mappings removed, "
-                f"{invalid_count} invalid, "
-                f"{len(to_insert_entries)} inserted"
+                "Mappings database sync complete: "
+                f"{len(removed_pairs)} removed, "
+                f"{len(updated_pairs)} updated, "
+                f"{len(created_pairs)} created"
             )

--- a/src/core/mappings.py
+++ b/src/core/mappings.py
@@ -9,6 +9,7 @@ from urllib.parse import urljoin, urlparse
 import aiohttp
 import orjson
 import yaml
+import zstandard
 from yaml import CSafeLoader as YamlLoader
 
 from src import __version__, log
@@ -108,7 +109,25 @@ class MappingsClient:
 
     def _decode_mappings(self, payload: bytes, src: str) -> AnimapDict:
         """Decode a raw JSON/YAML payload from a given source."""
-        suffix = Path(src).suffix.lower()
+        suffixes = [suffix.lower() for suffix in Path(src).suffixes]
+        if suffixes and suffixes[-1] == ".zst":
+            try:
+                payload = zstandard.ZstdDecompressor().decompress(payload)
+                suffixes = suffixes[:-1]
+            except zstandard.ZstdError:
+                log.error(
+                    f"Error decompressing Zstandard payload $$'{src}'$$",
+                    exc_info=True,
+                )
+                return {}
+            except Exception:
+                log.error(
+                    f"Unexpected error decompressing Zstandard payload $$'{src}'$$",
+                    exc_info=True,
+                )
+                return {}
+
+        suffix = suffixes[-1] if suffixes else ""
         try:
             if suffix in {".yaml", ".yml"}:
                 return self._dict_str_keys(

--- a/tests/core/sync/test_base_client.py
+++ b/tests/core/sync/test_base_client.py
@@ -20,6 +20,7 @@ from src.core.sync.base import BaseSyncClient, diff_snapshots
 from src.core.sync.stats import EntrySnapshot, ItemIdentifier
 from src.models.db.pin import Pin
 from src.models.db.sync_history import SyncHistory, SyncOutcome
+from src.utils.terminal import ARROW
 from tests.core.sync.fakes import (
     FakeAnimapClient,
     FakeLibraryMovie,
@@ -210,9 +211,10 @@ def test_format_diff_serializes_status_and_datetimes(
         ),
     }
     result = stub_client._format_diff(diff)
-    assert "status: current -> completed" in result
+    assert f"status: current {ARROW} completed" in result
     assert (
-        "finished_at: 2025-02-01T00:00:00+00:00 -> 2025-02-01T00:00:00+00:00" in result
+        "finished_at: 2025-02-01T00:00:00+00:00 "
+        f"{ARROW} 2025-02-01T00:00:00+00:00" in result
     )
 
 

--- a/tests/core/test_animap.py
+++ b/tests/core/test_animap.py
@@ -296,3 +296,43 @@ def test_sync_db_skips_invalid_range_strings(
         ("1-6|2", "1-3|2,4-6|2"),
         ("2", "1,2"),
     }
+
+
+def test_sync_db_logs_distinct_mapping_changes(
+    animap_client: AnimapClient,
+    in_memory_db: AniBridgeDB,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sync log summarizes distinct mapping changes by source/target."""
+    initial_mappings = {
+        "anilist:1": {"tmdb:10": {"1": None}},
+        "anilist:2": {"tvdb:20": {"1-12": "1-12"}},
+        "anilist:3": {"tmdb:30": {"1": None}},
+    }
+    updated_mappings = {
+        "anilist:2": {"tvdb:20": {"1-13": "1-13"}},
+        "anilist:3": {"tmdb:30": {"1": None}},
+        "anilist:4": {"tmdb:40": {"1": None}},
+    }
+
+    fake_client = FakeMappingsClient(mappings=initial_mappings, provenance={})
+    animap_client.mappings_client = cast(MappingsClient, fake_client)
+
+    messages: list[str] = []
+
+    def _capture_success(*args, **kwargs) -> None:
+        if args:
+            messages.append(str(args[0]))
+
+    animap_module = importlib.import_module("src.core.animap")
+    monkeypatch.setattr(animap_module.log, "success", _capture_success)
+
+    asyncio.run(animap_client.sync_db())
+
+    fake_client.mappings = updated_mappings
+    asyncio.run(animap_client.sync_db())
+
+    assert messages
+    assert "1 removed" in messages[-1]
+    assert "1 updated" in messages[-1]
+    assert "1 created" in messages[-1]

--- a/uv.lock
+++ b/uv.lock
@@ -125,6 +125,7 @@ dependencies = [
     { name = "requests" },
     { name = "ruamel-yaml" },
     { name = "sqlalchemy" },
+    { name = "zstandard" },
 ]
 
 [package.dev-dependencies]
@@ -162,6 +163,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.5" },
     { name = "ruamel-yaml", specifier = ">=0.18.16" },
     { name = "sqlalchemy", specifier = ">=2.0.45" },
+    { name = "zstandard", specifier = ">=0.25.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1622,4 +1624,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]


### PR DESCRIPTION
### Description

This PR adds support for loading and decompressing Zstandard compressed JSON/YAML mappings files.

The PR also updates the default upstream mappings URL to `https://github.com/anibridge/anibridge-mappings/releases/latest/download/mappings.json.zst`, under the new anibridge-mappings repository.

**What's new:**

- Zstandard (`*.zst`) mappings support

### Checklist

- [x] I have performed a self-review of my own code
- [x] My code passes the test suite (`pytest`)
- [x] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
