### PR TITLE
Timeline debug info

### DIFF
--- a/alembic/versions/2026-02-23-22-55_0b5e4f0b749e.py
+++ b/alembic/versions/2026-02-23-22-55_0b5e4f0b749e.py
@@ -1,0 +1,28 @@
+"""Add sync history info payload
+
+Revision ID: 0b5e4f0b749e
+Revises: 38ae72352337
+Create Date: 2026-02-23 22:55:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0b5e4f0b749e"
+down_revision: Union[str, None] = "38ae72352337"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("sync_history", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("info", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("sync_history", schema=None) as batch_op:
+        batch_op.drop_column("info")

--- a/frontend/src/lib/components/timeline/timeline-global-pins-manager.svelte
+++ b/frontend/src/lib/components/timeline/timeline-global-pins-manager.svelte
@@ -131,6 +131,7 @@
             outcome,
             before_state: null,
             after_state: null,
+            info: null,
             error_message: null,
             timestamp,
             library_media: null,

--- a/frontend/src/lib/components/timeline/timeline-item.svelte
+++ b/frontend/src/lib/components/timeline/timeline-item.svelte
@@ -4,6 +4,7 @@
     import {
         ExternalLink,
         Hash,
+        Info,
         LoaderCircle,
         RefreshCcw,
         RotateCw,
@@ -122,6 +123,22 @@
     }
 
     const timestampLabel = $derived(formatTimestamp(item.timestamp));
+    let openInfo = $state(false);
+    const infoEntries = $derived.by(() =>
+        Object.entries(item.info ?? {})
+            .map(([key, value]) => [key.trim(), String(value ?? "").trim()] as const)
+            .filter(([key, value]) => key.length > 0 && value.length > 0)
+            .sort(([left], [right]) => left.localeCompare(right)),
+    );
+    const hasInfo = $derived(infoEntries.length > 0);
+
+    $effect(() => {
+        if (!hasInfo) openInfo = false;
+    });
+
+    function formatInfoKey(key: string): string {
+        return titleCase(key.replaceAll("_", " ").replaceAll("-", " "));
+    }
 </script>
 
 {#snippet DefaultPins(props: PinsPanelContext)}
@@ -321,6 +338,25 @@
                                     {/if}
                                 </button>
                             {/if}
+                            {#if hasInfo}
+                                <button
+                                    type="button"
+                                    class={`diff-toggle inline-flex items-center gap-1 text-xs text-sky-400 hover:text-sky-300 ${
+                                        openInfo ? "open" : ""
+                                    }`}
+                                    onclick={() => (openInfo = !openInfo)}
+                                    aria-expanded={openInfo}
+                                    title="Show sync details">
+                                    <Info
+                                        class="diff-icon inline h-4 w-4 text-[14px]" />
+                                    <span class="diff-label relative"
+                                        >{openInfo ? "Hide debug" : "Debug"}</span>
+                                    <span
+                                        class="rounded bg-slate-800/70 px-1 text-[10px] font-semibold text-slate-200">
+                                        {infoEntries.length}
+                                    </span>
+                                </button>
+                            {/if}
                             {#if item.error_message}
                                 <div class="text-[11px] whitespace-nowrap text-red-400">
                                     {item.error_message}
@@ -377,6 +413,22 @@
     <TimelineDiffViewer
         {item}
         ui={ui()} />
+{/if}
+{#if openInfo && hasInfo}
+    <div class="ml-4 rounded-md border border-slate-800 bg-slate-900/40 p-3">
+        <dl class="grid gap-2 text-xs sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+            {#each infoEntries as [key, value] (key)}
+                <div
+                    class="rounded-md border border-slate-700/70 bg-slate-800/55 px-3 py-2.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+                    <dt
+                        class="mb-1 text-[10px] font-semibold tracking-[0.08em] text-slate-400 uppercase">
+                        {formatInfoKey(key)}
+                    </dt>
+                    <dd class="leading-relaxed wrap-break-word text-slate-100">{value}</dd>
+                </div>
+            {/each}
+        </dl>
+    </div>
 {/if}
 {#if openPins && hasPins}
     {@render (pinsPanel ?? DefaultPins)({

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -259,6 +259,7 @@ export interface HistoryItem {
     outcome: string;
     before_state?: Record<string, unknown> | null;
     after_state?: Record<string, unknown> | null;
+    info?: Record<string, string> | null;
     error_message?: string | null;
     timestamp: string;
     library_media?: ProviderMediaMetadata | null;

--- a/src/core/sync/base.py
+++ b/src/core/sync/base.py
@@ -470,6 +470,9 @@ class BaseSyncClient[
                 self.sync_stats.track_item(item_identifier, SyncOutcome.FAILED)
 
         if not found_match:
+            attempted_descriptors = tuple(
+                sorted(item.mapping_descriptors(), key=descriptor_key)
+            )
             log.warning(
                 "[%s] No list entries found for %s %s %s",
                 self.profile_name,
@@ -484,6 +487,17 @@ class BaseSyncClient[
                 snapshots=(None, None),
                 list_media_key=None,
                 outcome=SyncOutcome.NOT_FOUND,
+                info={
+                    "operation": "resolve_target",
+                    "reason": "no_matching_list_entry",
+                    "trackable_items": str(len(trackable)),
+                    "mapping_descriptor_count": str(len(attempted_descriptors)),
+                    "mapping_descriptors": ", ".join(
+                        descriptor_key(descriptor)
+                        for descriptor in attempted_descriptors
+                    ),
+                    "search_fallback_threshold": str(self.search_fallback_threshold),
+                },
             )
             if trackable:
                 self.sync_stats.track_items(trackable, SyncOutcome.NOT_FOUND)
@@ -570,6 +584,32 @@ class BaseSyncClient[
             self.list_provider.NAMESPACE, resolved_list_key
         )
         skip_fields = set(pinned_fields)
+        sync_fields_disabled = {
+            field_name
+            for field_name, rules in self.sync_fields.items()
+            if rules is False
+        }
+        pinned_blocked_fields: set[str] = set(skip_fields)
+        sync_rules_blocked: dict[str, str] = {}
+        status_gate_blocked: dict[str, str] = {}
+        destructive_blocked_fields: set[str] = set()
+        unchanged_fields: set[str] = set()
+
+        def mark_field_block(field_name: str, reason: str | None) -> None:
+            if reason is None:
+                return
+            if reason == "pinned":
+                pinned_blocked_fields.add(field_name)
+                return
+            if reason == "unchanged":
+                unchanged_fields.add(field_name)
+                return
+            if reason == "destructive_disabled":
+                destructive_blocked_fields.add(field_name)
+                return
+            if reason.startswith("sync_rules"):
+                _, _, detail = reason.partition(":")
+                sync_rules_blocked[field_name] = detail
 
         calc_kwargs = {
             "item": item,
@@ -615,6 +655,16 @@ class BaseSyncClient[
                     list_media_key=resolved_list_key,
                     mapping_descriptors=mapping_descriptors,
                     outcome=SyncOutcome.DELETED,
+                    info={
+                        "operation": "delete_entry",
+                        "reason": "status_resolved_to_none",
+                        "destructive_sync": self.destructive_sync,
+                        "sync_fields_disabled": sorted(sync_fields_disabled),
+                        "pinned_fields": ", ".join(sorted(skip_fields))
+                        if skip_fields
+                        else "",
+                        "mapping_descriptor_count": len(mapping_descriptors or ()),
+                    },
                 )
                 return SyncOutcome.DELETED
 
@@ -629,13 +679,16 @@ class BaseSyncClient[
 
         considered_attrs: set[str] = set()
 
-        if self._should_apply_field(
+        status_should_apply, status_reason = self._should_apply_field_with_reason(
             SyncField.STATUS,
             status_value,
             before_snapshot.status,
             skip_fields,
-        ):
+        )
+        if status_should_apply:
             entry.status = status_value
+        else:
+            mark_field_block(SyncField.STATUS.value, status_reason)
         considered_attrs.add(SyncField.STATUS.value)
         final_status = entry.status
 
@@ -643,24 +696,36 @@ class BaseSyncClient[
             if field == SyncField.STATUS:
                 continue
             if field.value in skip_fields:
+                pinned_blocked_fields.add(field.value)
                 continue
             if self.sync_fields.get(field.value) is False:
+                sync_fields_disabled.add(field.value)
                 continue
 
             if final_status is None:
+                status_gate_blocked[field.value] = "status_unset"
                 continue
             if (
                 field
                 in (SyncField.USER_RATING, SyncField.REPEATS, SyncField.FINISHED_AT)
                 and final_status < ListStatus.COMPLETED
             ):
+                status_gate_blocked[field.value] = "requires_completed"
                 continue
             if field == SyncField.STARTED_AT and final_status <= ListStatus.PLANNING:
+                status_gate_blocked[field.value] = "requires_active_status"
                 continue
 
             value = await self._field_calculators[field](**calc_kwargs)
             current_value = getattr(entry, field.value)
-            if not self._should_apply_field(field, value, current_value, skip_fields):
+            should_apply, apply_reason = self._should_apply_field_with_reason(
+                field,
+                value,
+                current_value,
+                skip_fields,
+            )
+            if not should_apply:
+                mark_field_block(field.value, apply_reason)
                 continue
 
             setattr(entry, field.value, value)
@@ -668,6 +733,30 @@ class BaseSyncClient[
 
         after_snapshot = EntrySnapshot.from_entry(entry)
         diff = diff_snapshots(before_snapshot, after_snapshot, considered_attrs)
+        sync_diagnostics = self._normalize_history_info(
+            {
+                "computed_status": status_value,
+                "final_status": final_status,
+                "sync_fields_disabled": sorted(sync_fields_disabled),
+                "pinned_blocked": sorted(pinned_blocked_fields),
+                "sync_rules_blocked": [
+                    f"{field_name}({rule_name})"
+                    if rule_name
+                    else field_name
+                    for field_name, rule_name in sorted(sync_rules_blocked.items())
+                ],
+                "status_gate_blocked": [
+                    f"{field_name}({rule_name})"
+                    if rule_name
+                    else field_name
+                    for field_name, rule_name in sorted(status_gate_blocked.items())
+                ],
+                "destructive_blocked": sorted(destructive_blocked_fields),
+                "unchanged_fields": sorted(unchanged_fields),
+                "considered_fields": sorted(considered_attrs),
+                "applied_fields": sorted(diff.keys()),
+            }
+        )
 
         if not diff:
             log.info(
@@ -693,15 +782,24 @@ class BaseSyncClient[
             entry=entry,
             list_media_key=resolved_list_key,
             mapping_descriptors=tuple(mapping_descriptors or ()),
+            diagnostics=sync_diagnostics,
         )
 
         diff_str = self._format_diff(diff)
-        return await self._apply_update(plan, diff_str, debug_title, debug_ids)
+        diff_fields = tuple(sorted(diff.keys()))
+        return await self._apply_update(
+            plan,
+            diff_str,
+            diff_fields,
+            debug_title,
+            debug_ids,
+        )
 
     async def _apply_update(
         self,
         plan: BatchUpdate[ParentMediaT, ChildMediaT],
         diff_str: str,
+        diff_fields: Sequence[str],
         debug_title: str,
         debug_ids: str,
     ) -> SyncOutcome:
@@ -747,6 +845,14 @@ class BaseSyncClient[
                 list_media_key=plan.list_media_key,
                 mapping_descriptors=plan.mapping_descriptors,
                 outcome=SyncOutcome.SYNCED,
+                info={
+                    **plan.diagnostics,
+                    "operation": "update_entry",
+                    "mode": "single",
+                    "changed_fields": ", ".join(diff_fields),
+                    "change_count": str(len(diff_fields)),
+                    "diff": diff_str,
+                },
             )
             return SyncOutcome.SYNCED
         except Exception as exc:
@@ -771,6 +877,15 @@ class BaseSyncClient[
                 mapping_descriptors=plan.mapping_descriptors,
                 outcome=SyncOutcome.FAILED,
                 error_message=str(exc),
+                info={
+                    **plan.diagnostics,
+                    "operation": "update_entry",
+                    "mode": "single",
+                    "changed_fields": ", ".join(diff_fields),
+                    "change_count": str(len(diff_fields)),
+                    "diff": diff_str,
+                    "error_type": type(exc).__name__,
+                },
             )
             raise
 
@@ -830,6 +945,18 @@ class BaseSyncClient[
                 entry.media().key for entry in updated if entry is not None
             }
             for update in self._pending_updates:
+                diff = diff_snapshots(
+                    update.before,
+                    update.after,
+                    set(update.after.to_dict().keys()),
+                )
+                diff_fields = tuple(sorted(diff.keys()))
+                diff_str = self._format_diff(diff)
+                outcome = (
+                    SyncOutcome.SYNCED
+                    if update.after.media_key in updated_list_keys
+                    else SyncOutcome.FAILED
+                )
                 await self._create_sync_history(
                     item=update.item,
                     child_item=update.child,
@@ -837,9 +964,15 @@ class BaseSyncClient[
                     snapshots=(update.before, update.after),
                     list_media_key=update.list_media_key,
                     mapping_descriptors=update.mapping_descriptors,
-                    outcome=SyncOutcome.SYNCED
-                    if update.after.media_key in updated_list_keys
-                    else SyncOutcome.FAILED,
+                    outcome=outcome,
+                    info={
+                        **update.diagnostics,
+                        "operation": "update_entry",
+                        "mode": "batch",
+                        "changed_fields": ", ".join(diff_fields),
+                        "change_count": str(len(diff_fields)),
+                        "diff": diff_str,
+                    },
                 )
             log.success(
                 "[%s] Batch sync completed for %s items with %s failures",
@@ -851,6 +984,13 @@ class BaseSyncClient[
             log.error("Batch sync failed: %s", exc)
             log.exception("Batch sync error details")
             for update in self._pending_updates:
+                diff = diff_snapshots(
+                    update.before,
+                    update.after,
+                    set(update.after.to_dict().keys()),
+                )
+                diff_fields = tuple(sorted(diff.keys()))
+                diff_str = self._format_diff(diff)
                 await self._create_sync_history(
                     item=update.item,
                     child_item=update.child,
@@ -860,10 +1000,63 @@ class BaseSyncClient[
                     mapping_descriptors=update.mapping_descriptors,
                     outcome=SyncOutcome.FAILED,
                     error_message=str(exc),
+                    info={
+                        **update.diagnostics,
+                        "operation": "update_entry",
+                        "mode": "batch",
+                        "changed_fields": ", ".join(diff_fields),
+                        "change_count": str(len(diff_fields)),
+                        "diff": diff_str,
+                        "error_type": type(exc).__name__,
+                    },
                 )
             raise
         finally:
             self._pending_updates.clear()
+
+    @staticmethod
+    def _stringify_history_info_value(value: Any) -> str | None:
+        """Convert supported values into non-empty strings."""
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, datetime):
+            dt = value
+            dt = dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt.astimezone(UTC)
+            return dt.isoformat()
+        if isinstance(value, ListStatus):
+            return value.value
+        if isinstance(value, (list, tuple, set)):
+            values = [
+                serialized
+                for serialized in (
+                    BaseSyncClient._stringify_history_info_value(item)
+                    for item in value
+                )
+                if serialized
+            ]
+            return ", ".join(values) if values else None
+        text = str(value).strip()
+        return text or None
+
+    def _normalize_history_info(
+        self,
+        payload: Mapping[str, Any] | None,
+    ) -> dict[str, str]:
+        """Normalize history metadata to a flat string dictionary."""
+        if not payload:
+            return {}
+        normalized: dict[str, str] = {}
+        for key, value in payload.items():
+            normalized_key = str(key).strip()
+            if not normalized_key:
+                continue
+            normalized_value = self._stringify_history_info_value(value)
+            if normalized_value is None:
+                continue
+            normalized[normalized_key] = normalized_value
+        return normalized
 
     async def _create_sync_history(
         self,
@@ -876,6 +1069,7 @@ class BaseSyncClient[
         mapping_descriptors: Sequence[MappingDescriptor] | None = None,
         outcome: SyncOutcome,
         error_message: str | None = None,
+        info: Mapping[str, Any] | None = None,
     ) -> None:
         """Record the outcome of a sync attempt."""
         before_snapshot, after_snapshot = snapshots
@@ -898,6 +1092,50 @@ class BaseSyncClient[
         library_media_key = str(library_target.key)
         list_namespace = self.list_provider.NAMESPACE
         media_kind = library_target.media_kind
+        mapping_target_descriptors = sorted(
+            set(mapping_descriptors or ()),
+            key=descriptor_key,
+        )
+
+        changed_fields: tuple[str, ...] = tuple()
+        if before_snapshot or after_snapshot:
+            candidate_fields = set()
+            if before_snapshot:
+                candidate_fields.update(before_snapshot.to_dict().keys())
+            if after_snapshot:
+                candidate_fields.update(after_snapshot.to_dict().keys())
+            changed_fields = tuple(
+                sorted(
+                    diff_snapshots(
+                        before_snapshot,
+                        after_snapshot,
+                        candidate_fields,
+                    )
+                )
+            )
+
+        base_info = self._normalize_history_info(
+            {
+                "outcome": outcome.value,
+                "library_section_key": library_section_key,
+                "library_media_key": library_media_key,
+                "list_media_key": resolved_list_media_key,
+                "mapping_targets": [
+                    descriptor_key(descriptor)
+                    for descriptor in mapping_target_descriptors
+                ],
+                "mapping_count": len(mapping_target_descriptors),
+                "grandchild_count": len(grandchild_items or ()),
+                "before_status": before_snapshot.status if before_snapshot else None,
+                "after_status": after_snapshot.status if after_snapshot else None,
+                "changed_fields": changed_fields,
+            }
+        )
+        extra_info = self._normalize_history_info(info)
+        history_info = {
+            **base_info,
+            **extra_info,
+        }
 
         with db() as ctx:
             if outcome == SyncOutcome.SYNCED:
@@ -949,12 +1187,16 @@ class BaseSyncClient[
                     )
                 existing = ctx.session.query(SyncHistory).filter(*filters).first()
                 if existing:
-                    if existing.error_message == error_message:
+                    if (
+                        existing.error_message == error_message
+                        and (existing.info or {}) == history_info
+                    ):
                         # If we're just seeing the same error, don't bring the record
                         # forward by updating the timestamp
                         return
                     existing.before_state = before_state
                     existing.after_state = after_state
+                    existing.info = history_info
                     existing.error_message = error_message
                     existing.timestamp = datetime.now(UTC)
                     existing.animap_entry_id = mapping_entry_id
@@ -973,6 +1215,7 @@ class BaseSyncClient[
                 outcome=outcome,
                 before_state=before_state,
                 after_state=after_state,
+                info=history_info,
                 error_message=error_message,
             )
             ctx.session.add(history_record)
@@ -1072,15 +1315,42 @@ class BaseSyncClient[
         skip_fields: set[str],
     ) -> bool:
         """Determine whether a field should be updated based on its rule."""
-        if field.value in skip_fields or current_value == new_value:
-            return False
+        should_apply, _ = self._should_apply_field_with_reason(
+            field,
+            new_value,
+            current_value,
+            skip_fields,
+        )
+        return should_apply
+
+    def _should_apply_field_with_reason(
+        self,
+        field: SyncField,
+        new_value: Comparable | None,
+        current_value: Comparable | None,
+        skip_fields: set[str],
+    ) -> tuple[bool, str | None]:
+        """Return whether field should be applied and a diagnostic reason."""
+        if field.value in skip_fields:
+            return False, "pinned"
+        if current_value == new_value:
+            return False, "unchanged"
         if (
             not self.destructive_sync
             and current_value is not None
             and new_value is None
         ):
-            return False
-        return self._is_sync_field_allowed(field, current_value, new_value)
+            return False, "destructive_disabled"
+        allowed, rule_reason = self._is_sync_field_allowed_with_reason(
+            field,
+            current_value,
+            new_value,
+        )
+        if allowed:
+            return True, "applied"
+        return False, (
+            f"sync_rules:{rule_reason}" if rule_reason is not None else "sync_rules"
+        )
 
     def _is_sync_field_allowed(
         self,
@@ -1089,14 +1359,28 @@ class BaseSyncClient[
         new_value: Comparable | None,
     ) -> bool:
         """Check if syncing a field is allowed based on the sync_fields rules."""
+        allowed, _ = self._is_sync_field_allowed_with_reason(
+            field,
+            current_value,
+            new_value,
+        )
+        return allowed
+
+    def _is_sync_field_allowed_with_reason(
+        self,
+        field: SyncField,
+        current_value: Comparable | None,
+        new_value: Comparable | None,
+    ) -> tuple[bool, str | None]:
+        """Check if sync_fields allows this update and return blocking rule."""
         rules = self.sync_fields.get(field.value)
         if rules is None:
-            return True
+            return True, None
         if isinstance(rules, bool):
-            return rules
+            return rules, "disabled" if not rules else None
 
         if isinstance(new_value, ListStatus) and rules.get(new_value.value) is False:
-            return False
+            return False, new_value.value
 
         if current_value is not None and new_value is not None:
             for key, blocked in (
@@ -1106,11 +1390,13 @@ class BaseSyncClient[
                 ("_gte", new_value >= current_value),
             ):
                 if rules.get(key, True) is False and blocked:
-                    return False
+                    return False, key
 
         if rules.get("_eq", True) is False and new_value == current_value:
-            return False
-        return not (rules.get("_ne", True) is False and new_value != current_value)
+            return False, "_eq"
+        if rules.get("_ne", True) is False and new_value != current_value:
+            return False, "_ne"
+        return True, None
 
     def _format_diff(self, diff: dict[str, tuple[Any, Any]]) -> str:
         """Format a diff dictionary for logging."""

--- a/src/core/sync/base.py
+++ b/src/core/sync/base.py
@@ -496,7 +496,6 @@ class BaseSyncClient[
                         descriptor_key(descriptor)
                         for descriptor in attempted_descriptors
                     ),
-                    "search_fallback_threshold": str(self.search_fallback_threshold),
                 },
             )
             if trackable:
@@ -740,15 +739,11 @@ class BaseSyncClient[
                 "sync_fields_disabled": sorted(sync_fields_disabled),
                 "pinned_blocked": sorted(pinned_blocked_fields),
                 "sync_rules_blocked": [
-                    f"{field_name}({rule_name})"
-                    if rule_name
-                    else field_name
+                    f"{field_name}({rule_name})" if rule_name else field_name
                     for field_name, rule_name in sorted(sync_rules_blocked.items())
                 ],
                 "status_gate_blocked": [
-                    f"{field_name}({rule_name})"
-                    if rule_name
-                    else field_name
+                    f"{field_name}({rule_name})" if rule_name else field_name
                     for field_name, rule_name in sorted(status_gate_blocked.items())
                 ],
                 "destructive_blocked": sorted(destructive_blocked_fields),
@@ -786,11 +781,9 @@ class BaseSyncClient[
         )
 
         diff_str = self._format_diff(diff)
-        diff_fields = tuple(sorted(diff.keys()))
         return await self._apply_update(
             plan,
             diff_str,
-            diff_fields,
             debug_title,
             debug_ids,
         )
@@ -799,7 +792,6 @@ class BaseSyncClient[
         self,
         plan: BatchUpdate[ParentMediaT, ChildMediaT],
         diff_str: str,
-        diff_fields: Sequence[str],
         debug_title: str,
         debug_ids: str,
     ) -> SyncOutcome:
@@ -849,9 +841,6 @@ class BaseSyncClient[
                     **plan.diagnostics,
                     "operation": "update_entry",
                     "mode": "single",
-                    "changed_fields": ", ".join(diff_fields),
-                    "change_count": str(len(diff_fields)),
-                    "diff": diff_str,
                 },
             )
             return SyncOutcome.SYNCED
@@ -881,9 +870,6 @@ class BaseSyncClient[
                     **plan.diagnostics,
                     "operation": "update_entry",
                     "mode": "single",
-                    "changed_fields": ", ".join(diff_fields),
-                    "change_count": str(len(diff_fields)),
-                    "diff": diff_str,
                     "error_type": type(exc).__name__,
                 },
             )
@@ -945,13 +931,6 @@ class BaseSyncClient[
                 entry.media().key for entry in updated if entry is not None
             }
             for update in self._pending_updates:
-                diff = diff_snapshots(
-                    update.before,
-                    update.after,
-                    set(update.after.to_dict().keys()),
-                )
-                diff_fields = tuple(sorted(diff.keys()))
-                diff_str = self._format_diff(diff)
                 outcome = (
                     SyncOutcome.SYNCED
                     if update.after.media_key in updated_list_keys
@@ -969,9 +948,6 @@ class BaseSyncClient[
                         **update.diagnostics,
                         "operation": "update_entry",
                         "mode": "batch",
-                        "changed_fields": ", ".join(diff_fields),
-                        "change_count": str(len(diff_fields)),
-                        "diff": diff_str,
                     },
                 )
             log.success(
@@ -984,13 +960,6 @@ class BaseSyncClient[
             log.error("Batch sync failed: %s", exc)
             log.exception("Batch sync error details")
             for update in self._pending_updates:
-                diff = diff_snapshots(
-                    update.before,
-                    update.after,
-                    set(update.after.to_dict().keys()),
-                )
-                diff_fields = tuple(sorted(diff.keys()))
-                diff_str = self._format_diff(diff)
                 await self._create_sync_history(
                     item=update.item,
                     child_item=update.child,
@@ -1004,9 +973,6 @@ class BaseSyncClient[
                         **update.diagnostics,
                         "operation": "update_entry",
                         "mode": "batch",
-                        "changed_fields": ", ".join(diff_fields),
-                        "change_count": str(len(diff_fields)),
-                        "diff": diff_str,
                         "error_type": type(exc).__name__,
                     },
                 )
@@ -1031,8 +997,7 @@ class BaseSyncClient[
             values = [
                 serialized
                 for serialized in (
-                    BaseSyncClient._stringify_history_info_value(item)
-                    for item in value
+                    BaseSyncClient._stringify_history_info_value(item) for item in value
                 )
                 if serialized
             ]
@@ -1097,23 +1062,6 @@ class BaseSyncClient[
             key=descriptor_key,
         )
 
-        changed_fields: tuple[str, ...] = tuple()
-        if before_snapshot or after_snapshot:
-            candidate_fields = set()
-            if before_snapshot:
-                candidate_fields.update(before_snapshot.to_dict().keys())
-            if after_snapshot:
-                candidate_fields.update(after_snapshot.to_dict().keys())
-            changed_fields = tuple(
-                sorted(
-                    diff_snapshots(
-                        before_snapshot,
-                        after_snapshot,
-                        candidate_fields,
-                    )
-                )
-            )
-
         base_info = self._normalize_history_info(
             {
                 "outcome": outcome.value,
@@ -1125,10 +1073,9 @@ class BaseSyncClient[
                     for descriptor in mapping_target_descriptors
                 ],
                 "mapping_count": len(mapping_target_descriptors),
-                "grandchild_count": len(grandchild_items or ()),
-                "before_status": before_snapshot.status if before_snapshot else None,
-                "after_status": after_snapshot.status if after_snapshot else None,
-                "changed_fields": changed_fields,
+                "grandchild_count": (
+                    len(grandchild_items) if grandchild_items is not None else None
+                ),
             }
         )
         extra_info = self._normalize_history_info(info)

--- a/src/core/sync/stats.py
+++ b/src/core/sync/stats.py
@@ -1,7 +1,7 @@
 """Synchronization statistics and tracking module."""
 
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Literal
 
@@ -367,3 +367,4 @@ class BatchUpdate[ParentMediaT: LibraryEntry, ChildMediaT: LibraryEntry]:
     entry: ListEntry
     list_media_key: str | None
     mapping_descriptors: tuple[MappingDescriptor, ...] = ()
+    diagnostics: dict[str, str] = field(default_factory=dict)

--- a/src/models/db/sync_history.py
+++ b/src/models/db/sync_history.py
@@ -59,6 +59,9 @@ class SyncHistory(Base):
     after_state: Mapped[dict[str, Any] | None] = mapped_column(
         JSON, default=dict, nullable=True
     )
+    info: Mapped[dict[str, str] | None] = mapped_column(
+        JSON, default=dict, nullable=True
+    )
 
     error_message: Mapped[str | None] = mapped_column(
         String, default=None, nullable=True

--- a/src/web/services/history_service.py
+++ b/src/web/services/history_service.py
@@ -45,6 +45,7 @@ class HistoryItem(BaseModel):
     outcome: str
     before_state: dict | None = None
     after_state: dict | None = None
+    info: dict[str, str] | None = None
     error_message: str | None = None
     timestamp: str
     library_media: ProviderMediaMetadata | None = None
@@ -161,6 +162,7 @@ class HistoryService:
                     outcome=str(row.outcome),
                     before_state=row.before_state,
                     after_state=row.after_state,
+                    info=row.info,
                     error_message=row.error_message,
                     timestamp=row.timestamp.isoformat(),
                     library_media=library_metadata,
@@ -476,6 +478,11 @@ class HistoryService:
                 await list_provider.update_entry(before_snapshot.media_key, entry)
 
         with db() as ctx:
+            source_info = {
+                str(key): str(value)
+                for key, value in (row.info or {}).items()
+                if str(key).strip() and value is not None
+            }
             undo_row = SyncHistory(
                 profile_name=row.profile_name,
                 library_namespace=row.library_namespace,
@@ -488,6 +495,12 @@ class HistoryService:
                 outcome=SyncOutcome.UNDONE,
                 before_state=row.after_state,
                 after_state=row.before_state,
+                info={
+                    **source_info,
+                    "operation": "undo",
+                    "source_history_id": str(row.id),
+                    "source_outcome": str(row.outcome),
+                },
             )
             ctx.session.add(undo_row)
             ctx.session.commit()

--- a/tests/core/sync/test_base_client.py
+++ b/tests/core/sync/test_base_client.py
@@ -446,6 +446,7 @@ async def test_apply_update_dry_run_returns_skipped(
     outcome = await stub_client._apply_update(
         plan,
         diff_str="progress: 0 → 1",
+        diff_fields=("progress",),
         debug_title="Movie",
         debug_ids="id",
     )
@@ -634,6 +635,7 @@ async def test_apply_update_raises_on_provider_error(
         await stub_client._apply_update(
             plan,
             diff_str="progress: 0 → 1",
+            diff_fields=("progress",),
             debug_title="Movie",
             debug_ids="id",
         )
@@ -758,6 +760,47 @@ async def test_sync_media_updates_entry_and_history(
         history = ctx.session.query(SyncHistory).all()
         assert len(history) == 1
         assert history[0].outcome == SyncOutcome.SYNCED
+        assert history[0].info is not None
+        assert history[0].info.get("operation") == "update_entry"
+        assert history[0].info.get("mode") == "single"
+        assert history[0].info.get("change_count") == "2"
+        assert history[0].info.get("changed_fields") == "progress, status"
+
+
+@pytest.mark.asyncio
+async def test_sync_media_info_reports_rule_and_status_blocks(
+    stub_client: StubSyncClient, sync_db
+) -> None:
+    """Sync diagnostics should include blocked fields and rule metadata."""
+    stub_client.sync_fields = {"progress": {"_gt": False}, "review": False}
+    movie = make_movie(view_count=2, user_rating=80)
+    provider = cast(FakeListProvider, stub_client.list_provider)
+    entry = FakeListEntry(
+        provider=provider,
+        key="movie-entry",
+        title="Movie",
+        media_type=ListMediaType.MOVIE,
+        total_units=1,
+    )
+    entry.progress = 0
+
+    result = await stub_client.sync_media(
+        item=movie,
+        child_item=movie,
+        grandchild_items=(movie,),
+        entry=cast(ListEntryProtocol, entry),
+        list_media_key=entry.media().key,
+    )
+
+    assert result is SyncOutcome.SYNCED
+    with sync_db as ctx:
+        record = ctx.session.query(SyncHistory).one()
+        assert record.info is not None
+        assert "progress(_gt)" in (record.info.get("sync_rules_blocked") or "")
+        assert "review" in (record.info.get("sync_fields_disabled") or "")
+        assert "user_rating(requires_completed)" in (
+            record.info.get("status_gate_blocked") or ""
+        )
 
 
 @pytest.mark.asyncio
@@ -943,6 +986,9 @@ async def test_process_media_marks_not_found(
     with sync_db as ctx:
         record = ctx.session.query(SyncHistory).one()
         assert record.outcome == SyncOutcome.NOT_FOUND
+        assert record.info is not None
+        assert record.info.get("operation") == "resolve_target"
+        assert record.info.get("reason") == "no_matching_list_entry"
 
 
 @pytest.mark.asyncio

--- a/tests/core/sync/test_base_client.py
+++ b/tests/core/sync/test_base_client.py
@@ -446,7 +446,6 @@ async def test_apply_update_dry_run_returns_skipped(
     outcome = await stub_client._apply_update(
         plan,
         diff_str="progress: 0 → 1",
-        diff_fields=("progress",),
         debug_title="Movie",
         debug_ids="id",
     )
@@ -635,7 +634,6 @@ async def test_apply_update_raises_on_provider_error(
         await stub_client._apply_update(
             plan,
             diff_str="progress: 0 → 1",
-            diff_fields=("progress",),
             debug_title="Movie",
             debug_ids="id",
         )
@@ -763,8 +761,6 @@ async def test_sync_media_updates_entry_and_history(
         assert history[0].info is not None
         assert history[0].info.get("operation") == "update_entry"
         assert history[0].info.get("mode") == "single"
-        assert history[0].info.get("change_count") == "2"
-        assert history[0].info.get("changed_fields") == "progress, status"
 
 
 @pytest.mark.asyncio
@@ -989,6 +985,7 @@ async def test_process_media_marks_not_found(
         assert record.info is not None
         assert record.info.get("operation") == "resolve_target"
         assert record.info.get("reason") == "no_matching_list_entry"
+        assert record.info.get("grandchild_count") is None
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_history_service.py
+++ b/tests/web/test_history_service.py
@@ -167,6 +167,7 @@ def _seed_history_row(*, clear: bool = True, **overrides) -> int:
             "outcome": SyncOutcome.SYNCED,
             "before_state": {"progress": 0},
             "after_state": {"progress": 1},
+            "info": {"source": "test-seed"},
             "error_message": None,
         }
         payload.update(overrides)
@@ -205,6 +206,7 @@ async def test_history_service_get_page_enriches_metadata(history_env):
     assert item.list_media is not None
     assert item.list_media.title == "List lst1"
     assert item.pinned_fields == ["status"]
+    assert item.info == {"source": "test-seed"}
 
     cache_info = service.get_cache_info()
     assert cache_info["list_cache"].hits >= 0
@@ -299,6 +301,22 @@ async def test_history_service_undo_item_deletes_entry_and_fails(history_env):
         await service.undo_item("profile", row_id)
 
     assert history_env.list_provider.deleted_entries == []
+
+
+@pytest.mark.asyncio
+async def test_history_service_undo_item_records_info(history_env):
+    """Undo entries keep an audit trail in the info payload."""
+    history_env.bridge.profile_config.destructive_sync = True
+    row_id = _seed_history_row(before_state=None)
+    service = HistoryService()
+
+    item = await service.undo_item("profile", row_id)
+
+    assert item.info is not None
+    assert item.info.get("operation") == "undo"
+    assert item.info.get("source_history_id") == str(row_id)
+    assert item.info.get("source_outcome") == SyncOutcome.SYNCED.value
+    assert history_env.list_provider.deleted_entries == ["lst1"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Description

This PR introduces an `info` column to the sync history table. It will store JSON key: value pairs of debug information. It'll be used for a behind-the-scenes look at the backed sync logic.

**What's new:**

- Debug sync information stored in the DB
- 'Debug' panel on the sync timeline page

### Database Migration

`0b5e4f0b749e`: Add sync history info payload

### Checklist

- [x] I have performed a self-review of my own code
- [x] My code passes the test suite (`pytest`)
- [x] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
