### PR TITLE
Configurable poll interval

### DIFF
--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -140,6 +140,7 @@ export interface ProfileConfig {
     library_user?: string | null;
     list_user?: string | null;
     scan_interval?: number | null;
+    poll_interval?: number | null;
     scan_modes?: string[];
     full_scan?: boolean | null;
     destructive_sync?: boolean | null;

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -115,7 +115,7 @@ class ScanMode(BaseStrEnum):
     Multiple modes can be enabled simultaneously by specifying a list.
 
     periodic: Periodic scans every `scan_interval` seconds
-    poll: Poll for incremental changes every 30 seconds
+    poll: Poll for incremental changes every `poll_interval` seconds
     webhook: External webhook-triggered syncs, dependent on `ab_web_enabled`
     """
 
@@ -204,6 +204,9 @@ class AniBridgeProfileConfig(BaseModel):
 
     scan_interval: int = Field(
         default=86400, ge=0, description="Scan interval in seconds"
+    )
+    poll_interval: int = Field(
+        default=60, ge=0, description="Poll scan interval in seconds"
     )
     scan_modes: list[ScanMode] = Field(
         default_factory=lambda: [ScanMode.PERIODIC, ScanMode.POLL, ScanMode.WEBHOOK],

--- a/src/core/bridge.py
+++ b/src/core/bridge.py
@@ -418,24 +418,40 @@ class BridgeClient:
             section.title,
         )
 
-        min_last_modified = (self.last_synced or datetime.now(UTC)) - timedelta(
-            seconds=15
+        min_last_modified = (
+            (self.last_synced or datetime.now(UTC)) - timedelta(seconds=15)
+            if poll
+            else None
         )
 
+        parts = []
+        if poll:
+            parts.append("poll=True")
+        if min_last_modified:
+            parts.append(f"min_last_modified={min_last_modified.isoformat()}")
+        if keys is not None:
+            parts.append(f"keys={list(keys)}")
+        debug_log_args = f" ({', '.join(parts)})" if parts else ""
+
+        log.debug(
+            "[%s] Fetching items in section $$'%s'$$%s",
+            self.profile_name,
+            section.title,
+            debug_log_args,
+        )
         items = list(
             await self.library_provider.list_items(
                 section,
-                min_last_modified=min_last_modified if poll else None,
+                min_last_modified=min_last_modified,
                 require_watched=not self.profile_config.full_scan,
                 keys=keys,
             )
         )
         log.debug(
-            "[%s] Found %s items in section $$'%s'$$ (poll=%s)",
+            "[%s] Found %s items in section $$'%s'$$",
             self.profile_name,
             len(items),
             section.title,
-            poll,
         )
 
         if self.current_sync is not None:

--- a/src/core/bridge.py
+++ b/src/core/bridge.py
@@ -425,10 +425,10 @@ class BridgeClient:
         )
 
         parts = []
-        if poll:
-            parts.append("poll=True")
         if min_last_modified:
             parts.append(f"min_last_modified={min_last_modified.isoformat()}")
+        if self.profile_config.full_scan:
+            parts.append("require_watched=False")
         if keys is not None:
             parts.append(f"keys={list(keys)}")
         debug_log_args = f" ({', '.join(parts)})" if parts else ""

--- a/src/core/sched/client.py
+++ b/src/core/sched/client.py
@@ -124,9 +124,10 @@ class SchedulerClient:
             profile_config = self.global_config.get_profile(profile_name)
 
             log.info(
-                "[%s] Starting scheduler: interval=%ss, modes=%s, full_scan=%s, "
-                "destructive=%s",
+                "[%s] Starting scheduler: poll_interval=%ss, scan_interval=%ss, "
+                "modes=%s, full_scan=%s, destructive=%s",
                 profile_name,
+                profile_config.poll_interval,
                 profile_config.scan_interval,
                 profile_config.scan_modes,
                 "enabled" if profile_config.full_scan else "disabled",
@@ -136,9 +137,9 @@ class SchedulerClient:
             scheduler = ProfileScheduler(
                 profile_name=profile_name,
                 bridge_client=bridge_client,
+                poll_interval=profile_config.poll_interval,
                 scan_interval=profile_config.scan_interval,
                 scan_modes=profile_config.scan_modes,
-                poll_interval=30,
                 before_sync=self._sync_coordinator.acquire_profile_slot,
                 after_sync=self._sync_coordinator.release_profile_slot,
                 stop_event=self.stop_event,
@@ -352,6 +353,7 @@ class SchedulerClient:
                     "library_user": library_user_title,
                     "list_user": list_user_title,
                     "scan_interval": profile_config.scan_interval,
+                    "poll_interval": profile_config.poll_interval,
                     "scan_modes": [m.value for m in profile_config.scan_modes],
                     "full_scan": profile_config.full_scan,
                     "destructive_sync": profile_config.destructive_sync,

--- a/src/core/sched/profile.py
+++ b/src/core/sched/profile.py
@@ -29,9 +29,9 @@ class ProfileScheduler:
         self,
         profile_name: str,
         bridge_client: BridgeClient,
+        poll_interval: int,
         scan_interval: int,
         scan_modes: list[ScanMode],
-        poll_interval: int = 30,
         max_pending_waiters: int = DEFAULT_MAX_PENDING_WAITERS,
         before_sync: Callable[[str], Awaitable[None]] | None = None,
         after_sync: Callable[[str], Awaitable[None]] | None = None,
@@ -42,9 +42,9 @@ class ProfileScheduler:
         Args:
             profile_name (str): The name of the profile this scheduler manages.
             bridge_client (BridgeClient): The bridge client used to perform syncs.
+            poll_interval (int): The interval in seconds for poll scans.
             scan_interval (int): The interval in seconds for periodic scans.
             scan_modes (list[ScanMode]): The scan modes enabled for this profile.
-            poll_interval (int): The interval in seconds for poll scans.
             max_pending_waiters (int): The maximum number of sync requests to queue.
             before_sync (Callable[[str], Awaitable[None]] | None): Optional callback to
                 run before each sync, receiving the profile name.
@@ -55,9 +55,9 @@ class ProfileScheduler:
         """
         self.profile_name = profile_name
         self.bridge_client = bridge_client
+        self.poll_interval = poll_interval
         self.scan_interval = scan_interval
         self.scan_modes = scan_modes
-        self.poll_interval = poll_interval
         self.max_pending_waiters = max_pending_waiters
         self._before_sync = before_sync
         self._after_sync = after_sync

--- a/src/web/routes/api/status.py
+++ b/src/web/routes/api/status.py
@@ -20,6 +20,7 @@ class ProfileConfigModel(BaseModel):
     list_namespace: str
     library_user: str | None = None
     list_user: str | None = None
+    poll_interval: int | None = None
     scan_interval: int | None = None
     scan_modes: list[str] = []
     full_scan: bool | None = None

--- a/tests/core/test_sched.py
+++ b/tests/core/test_sched.py
@@ -20,6 +20,7 @@ from src.exceptions import ProfileNotFoundError, SchedulerUnavailableError
 class FakeProfileConfig:
     """Minimal profile config stub."""
 
+    poll_interval: int = 60
     scan_interval: int = 10
     scan_modes: list[Any] = None  # type: ignore[assignment]
     full_scan: bool = False

--- a/uv.lock
+++ b/uv.lock
@@ -191,15 +191,15 @@ wheels = [
 
 [[package]]
 name = "anibridge-jellyfin-provider"
-version = "0.2.0b3"
+version = "0.2.0b4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anibridge-library-base" },
     { name = "jellyfin-sdk" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/71/0c99adb882b15ed9fed57a5b883a2cd5a363774b0c9cb64a1e556394fb03/anibridge_jellyfin_provider-0.2.0b3.tar.gz", hash = "sha256:4459d2a22aa90a05d20410319d2047f80a8ef8de81cdefce72bdf1a8fdeb08bb", size = 10527, upload-time = "2026-02-23T15:18:45.598Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/a9/2ad286046b4298a84e4520a593f4916a090ba748247c884cf40017ad2c83/anibridge_jellyfin_provider-0.2.0b4.tar.gz", hash = "sha256:1bf837f592fa0038c446303ccc2bcfff8c2b4e56c41d9b89fb68b35ac1622083", size = 11585, upload-time = "2026-02-26T04:19:26.33Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/bf/767a7b70cf38f5e408cae123d8d73bc4a183e4cde06fcbdfdc28b2eaf702/anibridge_jellyfin_provider-0.2.0b3-py3-none-any.whl", hash = "sha256:86425cbcfa853073d8305603cf7c3d09acb3c33a4925da6690eda27118b1aaba", size = 12924, upload-time = "2026-02-23T15:18:43.491Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7b/6c4f0c344b0fdd8c8c4741db31e0d559d8d8ff3ed67229f11f786d7bfa32/anibridge_jellyfin_provider-0.2.0b4-py3-none-any.whl", hash = "sha256:54489ea49f08c2246efeb4fff75cf5a7c11a95598803c908f18e6366600370d2", size = 13907, upload-time = "2026-02-26T04:19:25.261Z" },
 ]
 
 [[package]]
@@ -365,11 +365,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.1.4"
+version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
 ]
 
 [[package]]
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.132.0"
+version = "0.133.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -508,9 +508,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/55/f1b4d4e478a0a1b4b1113d0f610a1b08e539b69900f97fdc97155d62fdee/fastapi-0.132.0.tar.gz", hash = "sha256:ef687847936d8a57ea6ea04cf9a85fe5f2c6ba64e22bfa721467094b69d48d92", size = 372422, upload-time = "2026-02-23T17:56:22.218Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/6f/0eafed8349eea1fa462238b54a624c8b408cd1ba2795c8e64aa6c34f8ab7/fastapi-0.133.1.tar.gz", hash = "sha256:ed152a45912f102592976fde6cbce7dae1a8a1053da94202e51dd35d184fadd6", size = 378741, upload-time = "2026-02-25T18:18:17.398Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/de/6171c3363bbc5e01686e200e0880647c9270daa476d91030435cf14d32f5/fastapi-0.132.0-py3-none-any.whl", hash = "sha256:3c487d5afce196fa8ea509ae1531e96ccd5cdd2fd6eae78b73e2c20fba706689", size = 104652, upload-time = "2026-02-23T17:56:20.836Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c9/a175a7779f3599dfa4adfc97a6ce0e157237b3d7941538604aadaf97bfb6/fastapi-0.133.1-py3-none-any.whl", hash = "sha256:658f34ba334605b1617a65adf2ea6461901bdb9af3a3080d63ff791ecf7dc2e2", size = 109029, upload-time = "2026-02-25T18:18:18.578Z" },
 ]
 
 [package.optional-dependencies]
@@ -527,16 +527,16 @@ standard-no-fastapi-cloud-cli = [
 
 [[package]]
 name = "fastapi-cli"
-version = "0.0.23"
+version = "0.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "rich-toolkit" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/9f/cbd463e57de4e977b8ea0403f95347f9150441568b1d3fe3e4949ef80ef3/fastapi_cli-0.0.23.tar.gz", hash = "sha256:210ac280ea41e73aac5a57688781256beb23c2cba3a41266896fa43e6445c8e7", size = 19763, upload-time = "2026-02-16T19:45:53.358Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/58/74797ae9e4610cfa0c6b34c8309096d3b20bb29be3b8b5fbf1004d10fa5f/fastapi_cli-0.0.24.tar.gz", hash = "sha256:1afc9c9e21d7ebc8a3ca5e31790cd8d837742be7e4f8b9236e99cb3451f0de00", size = 19043, upload-time = "2026-02-24T10:45:10.476Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/89/19dcfd5cd289b306abdcabac68b88a4f54b7710a2c33adc16a337ecdcdfa/fastapi_cli-0.0.23-py3-none-any.whl", hash = "sha256:7e9634fc212da0b6cfc75bd3ac366cc9dfdb43b5e9ec12e58bfd1acdd2697f25", size = 12305, upload-time = "2026-02-16T19:45:52.554Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4b/68f9fe268e535d79c76910519530026a4f994ce07189ac0dded45c6af825/fastapi_cli-0.0.24-py3-none-any.whl", hash = "sha256:4a1f78ed798f106b4fee85ca93b85d8fe33c0a3570f775964d37edb80b8f0edc", size = 12304, upload-time = "2026-02-24T10:45:09.552Z" },
 ]
 
 [package.optional-dependencies]
@@ -1273,16 +1273,16 @@ wheels = [
 
 [[package]]
 name = "rich-toolkit"
-version = "0.19.4"
+version = "0.19.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/c9/4bbf4bfee195ed1b7d7a6733cc523ca61dbfb4a3e3c12ea090aaffd97597/rich_toolkit-0.19.4.tar.gz", hash = "sha256:52e23d56f9dc30d1343eb3b3f6f18764c313fbfea24e52e6a1d6069bec9c18eb", size = 193951, upload-time = "2026-02-12T10:08:15.814Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/ba/dae9e3096651042754da419a4042bc1c75e07d615f9b15066d738838e4df/rich_toolkit-0.19.7.tar.gz", hash = "sha256:133c0915872da91d4c25d85342d5ec1dfacc69b63448af1a08a0d4b4f23ef46e", size = 195877, upload-time = "2026-02-24T16:06:20.555Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/31/97d39719def09c134385bfcfbedfed255168b571e7beb3ad7765aae660ca/rich_toolkit-0.19.4-py3-none-any.whl", hash = "sha256:34ac344de8862801644be8b703e26becf44b047e687f208d7829e8f7cfc311d6", size = 32757, upload-time = "2026-02-12T10:08:15.037Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3c/c923619f6d2f5fafcc96fec0aaf9550a46cd5b6481f06e0c6b66a2a4fed0/rich_toolkit-0.19.7-py3-none-any.whl", hash = "sha256:0288e9203728c47c5a4eb60fd2f0692d9df7455a65901ab6f898437a2ba5989d", size = 32963, upload-time = "2026-02-24T16:06:22.066Z" },
 ]
 
 [[package]]
@@ -1330,26 +1330,28 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy"
-version = "2.0.46"
+version = "2.0.47"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/aa/9ce0f3e7a9829ead5c8ce549392f33a12c4555a6c0609bb27d882e9c7ddf/sqlalchemy-2.0.46.tar.gz", hash = "sha256:cf36851ee7219c170bb0793dbc3da3e80c582e04a5437bc601bfe8c85c9216d7", size = 9865393, upload-time = "2026-01-21T18:03:45.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/4b/1e00561093fe2cd8eef09d406da003c8a118ff02d6548498c1ae677d68d9/sqlalchemy-2.0.47.tar.gz", hash = "sha256:e3e7feb57b267fe897e492b9721ae46d5c7de6f9e8dee58aacf105dc4e154f3d", size = 9886323, upload-time = "2026-02-24T16:34:27.947Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/f8/5ecdfc73383ec496de038ed1614de9e740a82db9ad67e6e4514ebc0708a3/sqlalchemy-2.0.46-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:56bdd261bfd0895452006d5316cbf35739c53b9bb71a170a331fa0ea560b2ada", size = 2152079, upload-time = "2026-01-21T19:05:58.477Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/bf/eba3036be7663ce4d9c050bc3d63794dc29fbe01691f2bf5ccb64e048d20/sqlalchemy-2.0.46-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33e462154edb9493f6c3ad2125931e273bbd0be8ae53f3ecd1c161ea9a1dd366", size = 3272216, upload-time = "2026-01-21T18:46:52.634Z" },
-    { url = "https://files.pythonhosted.org/packages/05/45/1256fb597bb83b58a01ddb600c59fe6fdf0e5afe333f0456ed75c0f8d7bd/sqlalchemy-2.0.46-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bcdce05f056622a632f1d44bb47dbdb677f58cad393612280406ce37530eb6d", size = 3277208, upload-time = "2026-01-21T18:40:16.38Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a0/2053b39e4e63b5d7ceb3372cface0859a067c1ddbd575ea7e9985716f771/sqlalchemy-2.0.46-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e84b09a9b0f19accedcbeff5c2caf36e0dd537341a33aad8d680336152dc34e", size = 3221994, upload-time = "2026-01-21T18:46:54.622Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/87/97713497d9502553c68f105a1cb62786ba1ee91dea3852ae4067ed956a50/sqlalchemy-2.0.46-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4f52f7291a92381e9b4de9050b0a65ce5d6a763333406861e33906b8aa4906bf", size = 3243990, upload-time = "2026-01-21T18:40:18.253Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/87/5d1b23548f420ff823c236f8bea36b1a997250fd2f892e44a3838ca424f4/sqlalchemy-2.0.46-cp314-cp314-win32.whl", hash = "sha256:70ed2830b169a9960193f4d4322d22be5c0925357d82cbf485b3369893350908", size = 2114215, upload-time = "2026-01-21T18:42:55.232Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/20/555f39cbcf0c10cf452988b6a93c2a12495035f68b3dbd1a408531049d31/sqlalchemy-2.0.46-cp314-cp314-win_amd64.whl", hash = "sha256:3c32e993bc57be6d177f7d5d31edb93f30726d798ad86ff9066d75d9bf2e0b6b", size = 2139867, upload-time = "2026-01-21T18:42:56.474Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/f0/f96c8057c982d9d8a7a68f45d69c674bc6f78cad401099692fe16521640a/sqlalchemy-2.0.46-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4dafb537740eef640c4d6a7c254611dca2df87eaf6d14d6a5fca9d1f4c3fc0fa", size = 3561202, upload-time = "2026-01-21T18:33:10.337Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/53/3b37dda0a5b137f21ef608d8dfc77b08477bab0fe2ac9d3e0a66eaeab6fc/sqlalchemy-2.0.46-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:42a1643dc5427b69aca967dae540a90b0fbf57eaf248f13a90ea5930e0966863", size = 3526296, upload-time = "2026-01-21T18:45:12.657Z" },
-    { url = "https://files.pythonhosted.org/packages/33/75/f28622ba6dde79cd545055ea7bd4062dc934e0621f7b3be2891f8563f8de/sqlalchemy-2.0.46-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ff33c6e6ad006bbc0f34f5faf941cfc62c45841c64c0a058ac38c799f15b5ede", size = 3470008, upload-time = "2026-01-21T18:33:11.725Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/42/4afecbbc38d5e99b18acef446453c76eec6fbd03db0a457a12a056836e22/sqlalchemy-2.0.46-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:82ec52100ec1e6ec671563bbd02d7c7c8d0b9e71a0723c72f22ecf52d1755330", size = 3476137, upload-time = "2026-01-21T18:45:15.001Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/a1/9c4efa03300926601c19c18582531b45aededfb961ab3c3585f1e24f120b/sqlalchemy-2.0.46-py3-none-any.whl", hash = "sha256:f9c11766e7e7c0a2767dda5acb006a118640c9fc0a4104214b96269bfb78399e", size = 1937882, upload-time = "2026-01-21T18:22:10.456Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/30/98243209aae58ed80e090ea988d5182244ca7ab3ff59e6d850c3dfc7651e/sqlalchemy-2.0.47-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b03010a5a5dfe71676bc83f2473ebe082478e32d77e6f082c8fe15a31c3b42a6", size = 2154355, upload-time = "2026-02-24T17:05:48.959Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/62/12ca6ea92055fe486d6558a2a4efe93e194ff597463849c01f88e5adb99d/sqlalchemy-2.0.47-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f8e3371aa9024520883a415a09cc20c33cfd3eeccf9e0f4f4c367f940b9cbd44", size = 3274486, upload-time = "2026-02-24T17:18:13.659Z" },
+    { url = "https://files.pythonhosted.org/packages/97/88/7dfbdeaa8d42b1584e65d6cc713e9d33b6fa563e0d546d5cb87e545bb0e5/sqlalchemy-2.0.47-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9449f747e50d518c6e1b40cc379e48bfc796453c47b15e627ea901c201e48a6", size = 3279481, upload-time = "2026-02-24T17:27:26.491Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b7/75e1c1970616a9dd64a8a6fd788248da2ddaf81c95f4875f2a1e8aee4128/sqlalchemy-2.0.47-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:21410f60d5cac1d6bfe360e05bd91b179be4fa0aa6eea6be46054971d277608f", size = 3224269, upload-time = "2026-02-24T17:18:15.078Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ac/eec1a13b891df9a8bc203334caf6e6aac60b02f61b018ef3b4124b8c4120/sqlalchemy-2.0.47-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:819841dd5bb4324c284c09e2874cf96fe6338bfb57a64548d9b81a4e39c9871f", size = 3246262, upload-time = "2026-02-24T17:27:27.986Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b0/661b0245b06421058610da39f8ceb34abcc90b49f90f256380968d761dbe/sqlalchemy-2.0.47-cp314-cp314-win32.whl", hash = "sha256:e255ee44821a7ef45649c43064cf94e74f81f61b4df70547304b97a351e9b7db", size = 2116528, upload-time = "2026-02-24T17:22:59.363Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ef/1035a90d899e61810791c052004958be622a2cf3eb3df71c3fe20778c5d0/sqlalchemy-2.0.47-cp314-cp314-win_amd64.whl", hash = "sha256:209467ff73ea1518fe1a5aaed9ba75bb9e33b2666e2553af9ccd13387bf192cb", size = 2142181, upload-time = "2026-02-24T17:23:01.001Z" },
+    { url = "https://files.pythonhosted.org/packages/76/bb/17a1dd09cbba91258218ceb582225f14b5364d2683f9f5a274f72f2d764f/sqlalchemy-2.0.47-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e78fd9186946afaa287f8a1fe147ead06e5d566b08c0afcb601226e9c7322a64", size = 3563477, upload-time = "2026-02-24T17:12:18.46Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8f/1a03d24c40cc321ef2f2231f05420d140bb06a84f7047eaa7eaa21d230ba/sqlalchemy-2.0.47-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5740e2f31b5987ed9619d6912ae5b750c03637f2078850da3002934c9532f172", size = 3528568, upload-time = "2026-02-24T17:28:03.732Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/53/d56a213055d6b038a5384f0db5ece7343334aca230ff3f0fa1561106f22c/sqlalchemy-2.0.47-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb9ac00d03de93acb210e8ec7243fefe3e012515bf5fd2f0898c8dff38bc77a4", size = 3472284, upload-time = "2026-02-24T17:12:20.319Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/19/c235d81b9cfdd6130bf63143b7bade0dc4afa46c4b634d5d6b2a96bea233/sqlalchemy-2.0.47-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c72a0b9eb2672d70d112cb149fbaf172d466bc691014c496aaac594f1988e706", size = 3478410, upload-time = "2026-02-24T17:28:05.892Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/db/cafdeca5ecdaa3bb0811ba5449501da677ce0d83be8d05c5822da72d2e86/sqlalchemy-2.0.47-cp314-cp314t-win32.whl", hash = "sha256:c200db1128d72a71dc3c31c24b42eb9fd85b2b3e5a3c9ba1e751c11ac31250ff", size = 2147164, upload-time = "2026-02-24T17:14:40.783Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5e/ff41a010e9e0f76418b02ad352060a4341bb15f0af66cedc924ab376c7c6/sqlalchemy-2.0.47-cp314-cp314t-win_amd64.whl", hash = "sha256:669837759b84e575407355dcff912835892058aea9b80bd1cb76d6a151cf37f7", size = 2182154, upload-time = "2026-02-24T17:14:43.205Z" },
+    { url = "https://files.pythonhosted.org/packages/15/9f/7c378406b592fcf1fc157248607b495a40e3202ba4a6f1372a2ba6447717/sqlalchemy-2.0.47-py3-none-any.whl", hash = "sha256:e2647043599297a1ef10e720cf310846b7f31b6c841fee093d2b09d81215eb93", size = 1940159, upload-time = "2026-02-24T17:15:07.158Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

This PR adds the ability for users to configure a poll interval, mirroring the existing `sync_interval` behavior. Example usage:

```yaml
poll_interval: 60 # in seconds
```

**What's new:**

- New `poll_interval` config option
- The default poll interval has been increased to 60s to accommodate possibly less efficient library providers (compared to Plex)

**Improvements:**

- More visible debug logs for underlying filtering that happens when fetching section items


### Checklist

- [x] I have performed a self-review of my own code
- [x] My code passes the test suite (`pytest`)
- [x] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
