### PR TITLE
Restart server from frontend

### DIFF
--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -246,6 +246,11 @@ export interface MetaResponse {
     git_hash: string;
 }
 
+export interface RestartResponse {
+    ok: boolean;
+    message: string;
+}
+
 // --- History API ---
 export interface HistoryItem {
     id: number;

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -27,6 +27,8 @@
 
     let loading = $state(true);
     let saving = $state(false);
+    let restarting = $state(false);
+    let restartNotice: string | null = $state(null);
     let loadError: string | null = $state(null);
     let saveError: string | null = $state(null);
     let configAccessBlocked = $state(false);
@@ -39,7 +41,43 @@
 
     const hasChanges = $derived(editorValue !== initialValue);
 
-    onMount(loadConfig);
+    let restartPollGeneration = 0;
+
+    onMount(() => {
+        void loadConfig();
+        return () => {
+            restartPollGeneration += 1;
+        };
+    });
+
+    async function waitForServerAndRefresh() {
+        const generation = ++restartPollGeneration;
+        const deadline = Date.now() + 90_000;
+
+        while (Date.now() < deadline) {
+            if (generation !== restartPollGeneration) return;
+
+            await new Promise((resolve) => setTimeout(resolve, 2_000));
+
+            if (generation !== restartPollGeneration) return;
+
+            try {
+                const response = await apiFetch("/api/system/meta", undefined, {
+                    silent: true,
+                });
+                if (!response.ok) continue;
+
+                restarting = false;
+                restartNotice = null;
+                toast("AniBridge is back online.", "success");
+                await loadConfig();
+                return;
+            } catch {}
+        }
+
+        restarting = false;
+        restartNotice = "Restart is taking longer than expected. Use Reload to retry.";
+    }
 
     async function loadConfig() {
         loading = true;
@@ -104,6 +142,44 @@
         }
     }
 
+    async function restartServer() {
+        if (restarting || saving || loading) return;
+
+        const confirmed = window.confirm(
+            "Restart AniBridge now? The web UI will be briefly unavailable.",
+        );
+        if (!confirmed) return;
+
+        restarting = true;
+        saveError = null;
+        restartNotice = "Restart requested. Waiting for AniBridge to come back...";
+        try {
+            const response = await apiFetch("/api/system/restart", { method: "POST" });
+
+            if (!response.ok) {
+                const payload = await response.json().catch(() => null);
+                saveError = formatApiError(payload, response.status);
+                restarting = false;
+                restartNotice = null;
+                return;
+            }
+
+            toast("Restart requested. AniBridge will return in a few.", "success");
+            void waitForServerAndRefresh();
+        } catch (error) {
+            const msg = formatError(error);
+            if (/network|failed to fetch|load failed/i.test(msg)) {
+                toast("Restart in progress. Waiting for server to come back.", "info");
+                void waitForServerAndRefresh();
+                return;
+            }
+
+            saveError = msg;
+            restarting = false;
+            restartNotice = null;
+        }
+    }
+
     function revertChanges() {
         editorValue = initialValue;
         saveError = null;
@@ -157,7 +233,7 @@
                 type="button"
                 class="inline-flex items-center gap-1 rounded border border-slate-700 bg-slate-900/60 px-3 py-1 text-slate-100 hover:bg-slate-800/60"
                 onclick={loadConfig}
-                disabled={loading || saving}>
+                disabled={loading || saving || restarting}>
                 <RefreshCw class="h-3.5 w-3.5" /> Reload
             </button>
             <a
@@ -171,14 +247,30 @@
                 type="button"
                 class="inline-flex items-center gap-1 rounded border border-slate-700 bg-slate-900/60 px-3 py-1 text-slate-100 hover:bg-slate-800/60 disabled:opacity-50"
                 onclick={revertChanges}
-                disabled={loading || saving || configAccessBlocked || !hasChanges}>
+                disabled={loading ||
+                    saving ||
+                    restarting ||
+                    configAccessBlocked ||
+                    !hasChanges}>
                 Revert
+            </button>
+            <button
+                type="button"
+                class="inline-flex items-center gap-1 rounded border border-amber-500 bg-amber-600 px-4 py-1 font-semibold text-white hover:bg-amber-500 disabled:opacity-50"
+                onclick={restartServer}
+                disabled={loading || saving || restarting}>
+                <RefreshCw class={`h-3.5 w-3.5 ${restarting ? "animate-spin" : ""}`} />
+                {restarting ? "Restarting…" : "Restart Server"}
             </button>
             <button
                 type="button"
                 class="inline-flex items-center gap-1 rounded border border-blue-500 bg-blue-600 px-4 py-1 font-semibold text-white hover:bg-blue-500 disabled:opacity-50"
                 onclick={saveConfig}
-                disabled={loading || saving || configAccessBlocked || !hasChanges}>
+                disabled={loading ||
+                    saving ||
+                    restarting ||
+                    configAccessBlocked ||
+                    !hasChanges}>
                 <Save class="h-3.5 w-3.5" />
                 {saving ? "Saving…" : "Save"}
             </button>
@@ -230,6 +322,14 @@
             class="flex items-center gap-2 rounded border border-rose-900/60 bg-rose-950/60 px-3 py-2 text-xs text-rose-100">
             <TriangleAlert class="h-3.5 w-3.5" />
             {saveError}
+        </div>
+    {/if}
+
+    {#if restarting || restartNotice}
+        <div
+            class="flex items-center gap-2 rounded border border-amber-900/70 bg-amber-950/50 px-3 py-2 text-xs text-amber-100">
+            <LoaderCircle class={`h-3.5 w-3.5 ${restarting ? "animate-spin" : ""}`} />
+            {restartNotice ?? "Restarting AniBridge..."}
         </div>
     {/if}
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 """AniBridge Main Application."""
 
 import asyncio
+import os
 import signal
 import sys
 
@@ -11,6 +12,7 @@ from src import ANIBDRIGE_HEADER, log
 from src.config.settings import get_config
 from src.core.sched import SchedulerClient
 from src.web.app import create_app
+from src.web.state import get_app_state
 
 
 def _setup_signal_handlers_for_scheduler(scheduler: SchedulerClient) -> None:
@@ -181,6 +183,17 @@ async def run() -> int:
             except Exception as e:
                 log.error(f"AniBridge: Error during shutdown: {e}", exc_info=True)
                 ret = 1
+
+    app_state = get_app_state()
+    if app_state.restart_requested:
+        log.info("AniBridge: Restart requested, re-executing process...")
+        app_state.restart_requested = False
+        try:
+            os.execv(sys.executable, [sys.executable, *sys.argv])
+        except Exception as e:
+            log.error(f"AniBridge: Failed to restart process: {e}", exc_info=True)
+            ret = 1
+
     return ret
 
 

--- a/src/web/routes/api/system.py
+++ b/src/web/routes/api/system.py
@@ -81,6 +81,11 @@ class MetaResponse(BaseModel):
     git_hash: str
 
 
+class RestartResponse(BaseModel):
+    ok: bool
+    message: str
+
+
 router = APIRouter()
 
 
@@ -269,3 +274,34 @@ def meta() -> MetaResponse:
         dict[str, str]: The application metadata.
     """
     return MetaResponse(version=__version__, git_hash=__git_hash__)
+
+
+@router.post(
+    "/restart",
+    summary="Request graceful server restart",
+    response_model=RestartResponse,
+    status_code=202,
+)
+def api_restart() -> RestartResponse:
+    """Request a graceful scheduler shutdown and process restart.
+
+    Returns:
+        RestartResponse: Accepted restart request status.
+
+    Raises:
+        SchedulerUnavailableError: If scheduler is unavailable.
+    """
+    app_state = get_app_state()
+    scheduler = app_state.scheduler
+    if not scheduler:
+        raise SchedulerUnavailableError(
+            "Scheduler not available; restart unsupported in this mode"
+        )
+
+    app_state.request_restart()
+    scheduler.request_shutdown()
+
+    return RestartResponse(
+        ok=True,
+        message="Restart requested. AniBridge will restart shortly.",
+    )

--- a/src/web/routes/api/system.py
+++ b/src/web/routes/api/system.py
@@ -12,11 +12,13 @@ try:
 except ImportError:  # Windows does not have resource module
     resource = None  # ty:ignore[invalid-assignment]
 
+from fastapi import Depends
 from fastapi.routing import APIRouter
 from pydantic import BaseModel
 
 from src import __git_hash__, __version__
 from src.exceptions import AniBridgeError, SchedulerUnavailableError
+from src.web.routes.api.config import require_config_api_access
 from src.web.routes.api.status import (
     ProfileConfigModel,
     ProfileRuntimeStatusModel,
@@ -279,6 +281,7 @@ def meta() -> MetaResponse:
 @router.post(
     "/restart",
     summary="Request graceful server restart",
+    dependencies=[Depends(require_config_api_access)],
     response_model=RestartResponse,
     status_code=202,
 )

--- a/src/web/state.py
+++ b/src/web/state.py
@@ -29,6 +29,7 @@ class AppState:
         self.public_anilist: AniListClient | None = None
         self.on_shutdown_callbacks: list[Callable[[], Any]] = []
         self.started_at: datetime = datetime.now(UTC)
+        self.restart_requested: bool = False
 
     def set_scheduler(self, scheduler: SchedulerClient) -> None:
         """Set the scheduler client.
@@ -45,6 +46,10 @@ class AppState:
             cb (Callable[[], Any]): The callback function to register.
         """
         self.on_shutdown_callbacks.append(cb)
+
+    def request_restart(self) -> None:
+        """Mark that a full process restart was requested."""
+        self.restart_requested = True
 
     async def ensure_public_anilist(self) -> AniListClient:
         """Get or create the shared public AniList client.

--- a/tests/web/test_system_api.py
+++ b/tests/web/test_system_api.py
@@ -1,8 +1,13 @@
 """Tests for system API endpoints."""
 
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from pytest import raises
 
 from src.exceptions import SchedulerUnavailableError
+from src.web.routes.api import config as config_api_module
 from src.web.routes.api import system as system_api_module
 
 
@@ -21,6 +26,12 @@ class _DummyAppState:
 
     def request_restart(self) -> None:
         self.restart_requested = True
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(system_api_module.router, prefix="/api/system")
+    return app
 
 
 def test_api_restart_requests_scheduler_shutdown(monkeypatch) -> None:
@@ -44,3 +55,54 @@ def test_api_restart_requires_scheduler(monkeypatch) -> None:
 
     with raises(SchedulerUnavailableError):
         system_api_module.api_restart()
+
+
+def test_restart_api_blocked_without_auth_or_override(monkeypatch) -> None:
+    """Restart API should be blocked when config API access is blocked."""
+    monkeypatch.setattr(
+        config_api_module,
+        "runtime_config",
+        SimpleNamespace(
+            web=SimpleNamespace(
+                has_auth=False,
+                allow_config_without_auth=False,
+            )
+        ),
+        raising=False,
+    )
+
+    state = _DummyAppState(scheduler=_DummyScheduler())
+    monkeypatch.setattr(system_api_module, "get_app_state", lambda: state)
+
+    client = TestClient(_build_app())
+    response = client.post("/api/system/restart")
+
+    assert response.status_code == 403
+    assert "Configuration API is disabled" in response.json()["detail"]
+    assert state.restart_requested is False
+
+
+def test_restart_api_allowed_with_unauthenticated_override(monkeypatch) -> None:
+    """Restart API should be available when unauthenticated override is enabled."""
+    monkeypatch.setattr(
+        config_api_module,
+        "runtime_config",
+        SimpleNamespace(
+            web=SimpleNamespace(
+                has_auth=False,
+                allow_config_without_auth=True,
+            )
+        ),
+        raising=False,
+    )
+
+    scheduler = _DummyScheduler()
+    state = _DummyAppState(scheduler=scheduler)
+    monkeypatch.setattr(system_api_module, "get_app_state", lambda: state)
+
+    client = TestClient(_build_app())
+    response = client.post("/api/system/restart")
+
+    assert response.status_code == 202
+    assert state.restart_requested is True
+    assert scheduler.shutdown_requested is True

--- a/tests/web/test_system_api.py
+++ b/tests/web/test_system_api.py
@@ -1,0 +1,46 @@
+"""Tests for system API endpoints."""
+
+from pytest import raises
+
+from src.exceptions import SchedulerUnavailableError
+from src.web.routes.api import system as system_api_module
+
+
+class _DummyScheduler:
+    def __init__(self) -> None:
+        self.shutdown_requested = False
+
+    def request_shutdown(self) -> None:
+        self.shutdown_requested = True
+
+
+class _DummyAppState:
+    def __init__(self, scheduler: _DummyScheduler | None) -> None:
+        self.scheduler = scheduler
+        self.restart_requested = False
+
+    def request_restart(self) -> None:
+        self.restart_requested = True
+
+
+def test_api_restart_requests_scheduler_shutdown(monkeypatch) -> None:
+    """Restart endpoint should mark restart and request scheduler shutdown."""
+    scheduler = _DummyScheduler()
+    state = _DummyAppState(scheduler=scheduler)
+    monkeypatch.setattr(system_api_module, "get_app_state", lambda: state)
+
+    response = system_api_module.api_restart()
+
+    assert response.ok is True
+    assert "Restart requested" in response.message
+    assert state.restart_requested is True
+    assert scheduler.shutdown_requested is True
+
+
+def test_api_restart_requires_scheduler(monkeypatch) -> None:
+    """Restart endpoint should fail when scheduler is unavailable."""
+    state = _DummyAppState(scheduler=None)
+    monkeypatch.setattr(system_api_module, "get_app_state", lambda: state)
+
+    with raises(SchedulerUnavailableError):
+        system_api_module.api_restart()


### PR DESCRIPTION
### Description

This PR introduces the ability for users to (cold) restart their AniBridge server from the settings page of the web UI. The intended use case is to reboot from the web config editor so config changes can be applied.

**What's new:**

- Restart endpoint at `/api/system/restart` (must have auth enabled)
- Restart interface with connection polling on frontend
### Checklist

- [x] I have performed a self-review of my own code
- [x] My code passes the test suite (`pytest`)
- [x] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
