### PR TITLE
Add auto_rewatch feature for status promotion

### DIFF
--- a/src/anibridge/app/config/settings.py
+++ b/src/anibridge/app/config/settings.py
@@ -248,8 +248,8 @@ class AniBridgeProfileConfig(BaseModel):
     auto_rewatch: bool = Field(
         default=False,
         description=(
-            "When enabled, automatically set status to rewatching on the list provider "
-            "if the entry is already marked as completed or rewatching and new watch "
+            "When enabled, automatically set status to repeating on the list provider "
+            "if the entry is already marked as completed or repeating and new watch "
             "activity is detected in the library"
         ),
     )

--- a/src/anibridge/app/config/settings.py
+++ b/src/anibridge/app/config/settings.py
@@ -245,6 +245,14 @@ class AniBridgeProfileConfig(BaseModel):
     search_fallback_threshold: int = Field(
         default=-1, ge=-1, le=100, description="Fuzzy search threshold"
     )
+    auto_rewatch: bool = Field(
+        default=False,
+        description=(
+            "When enabled, automatically set status to rewatching on the list provider "
+            "if the entry is already marked as completed or rewatching and new watch "
+            "activity is detected in the library"
+        ),
+    )
     backup_retention_days: int = Field(
         default=30,
         ge=-1,

--- a/src/anibridge/app/config/settings.py
+++ b/src/anibridge/app/config/settings.py
@@ -245,7 +245,7 @@ class AniBridgeProfileConfig(BaseModel):
     search_fallback_threshold: int = Field(
         default=-1, ge=-1, le=100, description="Fuzzy search threshold"
     )
-    auto_rewatch: bool = Field(
+    promote_rewatch: bool = Field(
         default=False,
         description=(
             "When enabled, automatically set status to repeating on the list provider "

--- a/src/anibridge/app/core/bridge.py
+++ b/src/anibridge/app/core/bridge.py
@@ -262,6 +262,7 @@ class BridgeClient:
             search_fallback_threshold=self.profile_config.search_fallback_threshold,
             batch_requests=self.profile_config.batch_requests,
             dry_run=self.profile_config.dry_run,
+            auto_rewatch=self.profile_config.auto_rewatch,
             profile_name=self.profile_name,
         )
         show_sync = ShowSyncClient(
@@ -275,6 +276,7 @@ class BridgeClient:
             search_fallback_threshold=self.profile_config.search_fallback_threshold,
             batch_requests=self.profile_config.batch_requests,
             dry_run=self.profile_config.dry_run,
+            auto_rewatch=self.profile_config.auto_rewatch,
             profile_name=self.profile_name,
         )
 

--- a/src/anibridge/app/core/bridge.py
+++ b/src/anibridge/app/core/bridge.py
@@ -262,7 +262,7 @@ class BridgeClient:
             search_fallback_threshold=self.profile_config.search_fallback_threshold,
             batch_requests=self.profile_config.batch_requests,
             dry_run=self.profile_config.dry_run,
-            auto_rewatch=self.profile_config.auto_rewatch,
+            promote_rewatch=self.profile_config.promote_rewatch,
             profile_name=self.profile_name,
         )
         show_sync = ShowSyncClient(
@@ -276,7 +276,7 @@ class BridgeClient:
             search_fallback_threshold=self.profile_config.search_fallback_threshold,
             batch_requests=self.profile_config.batch_requests,
             dry_run=self.profile_config.dry_run,
-            auto_rewatch=self.profile_config.auto_rewatch,
+            promote_rewatch=self.profile_config.promote_rewatch,
             profile_name=self.profile_name,
         )
 

--- a/src/anibridge/app/core/sync/base.py
+++ b/src/anibridge/app/core/sync/base.py
@@ -101,6 +101,7 @@ class BaseSyncClient[
         dry_run: bool,
         profile_name: str,
         sync_fields: Mapping[SyncField, bool | Mapping[str, bool]] | None = None,
+        auto_rewatch: bool = False,
     ) -> None:
         """Initialize the base synchronisation client."""
         self.library_provider: LibraryProvider = library_provider
@@ -120,6 +121,7 @@ class BaseSyncClient[
         self.search_fallback_threshold: int = search_fallback_threshold
         self.batch_requests: bool = batch_requests
         self.dry_run: bool = dry_run
+        self.auto_rewatch: bool = auto_rewatch
         self.profile_name: str = profile_name
 
         self.sync_stats: SyncStats = SyncStats()
@@ -677,6 +679,14 @@ class BaseSyncClient[
                 debug_ids,
             )
             return SyncOutcome.SKIPPED
+
+        if (
+            self.auto_rewatch
+            and status_value == ListStatus.CURRENT
+            and before_snapshot.status
+            in (ListStatus.COMPLETED, ListStatus.REPEATING)
+        ):
+            status_value = ListStatus.REPEATING
 
         considered_attrs: set[str] = set()
 

--- a/src/anibridge/app/core/sync/base.py
+++ b/src/anibridge/app/core/sync/base.py
@@ -101,7 +101,7 @@ class BaseSyncClient[
         dry_run: bool,
         profile_name: str,
         sync_fields: Mapping[SyncField, bool | Mapping[str, bool]] | None = None,
-        auto_rewatch: bool = False,
+        promote_rewatch: bool = False,
     ) -> None:
         """Initialize the base synchronisation client."""
         self.library_provider: LibraryProvider = library_provider
@@ -121,7 +121,7 @@ class BaseSyncClient[
         self.search_fallback_threshold: int = search_fallback_threshold
         self.batch_requests: bool = batch_requests
         self.dry_run: bool = dry_run
-        self.auto_rewatch: bool = auto_rewatch
+        self.promote_rewatch: bool = promote_rewatch
         self.profile_name: str = profile_name
 
         self.sync_stats: SyncStats = SyncStats()
@@ -680,13 +680,20 @@ class BaseSyncClient[
             )
             return SyncOutcome.SKIPPED
 
+        promoted_current_to_repeating = False
         if (
-            self.auto_rewatch
+            self.promote_rewatch
             and status_value == ListStatus.CURRENT
-            and before_snapshot.status
-            in (ListStatus.COMPLETED, ListStatus.REPEATING)
+            and before_snapshot.status in (ListStatus.COMPLETED, ListStatus.REPEATING)
         ):
+            promoted_current_to_repeating = True
             status_value = ListStatus.REPEATING
+            log.debug(
+                "[%s] Promoting status CURRENT -> REPEATING (promote_rewatch) %s %s",
+                self.profile_name,
+                debug_title,
+                debug_ids,
+            )
 
         considered_attrs: set[str] = set()
 
@@ -748,6 +755,7 @@ class BaseSyncClient[
             {
                 "computed_status": status_value,
                 "final_status": final_status,
+                "promoted_current_to_repeating": promoted_current_to_repeating,
                 "sync_fields_disabled": sorted(sync_fields_disabled),
                 "pinned_blocked": sorted(pinned_blocked_fields),
                 "sync_rules_blocked": [

--- a/tests/core/sync/test_base_client.py
+++ b/tests/core/sync/test_base_client.py
@@ -993,3 +993,114 @@ async def test_process_media_skips_untrackable_items(
     await stub_client.process_media(movie)
 
     assert stub_client.sync_stats.skipped == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_rewatch_promotes_current_to_repeating_when_completed(
+    stub_client: StubSyncClient, sync_db
+) -> None:
+    """auto_rewatch=True should change CURRENT to REPEATING when entry is COMPLETED."""
+    stub_client.auto_rewatch = True
+    stub_client._status_override = ListStatus.CURRENT
+
+    provider = cast(Any, stub_client.list_provider)
+    movie = make_movie()
+    entry = FakeListEntry(
+        provider=provider,
+        key="m1",
+        title="Movie",
+        media_type=ListMediaType.MOVIE,
+    )
+    entry.status = ListStatus.COMPLETED
+
+    stub_client._trackable_items = [ItemIdentifier.from_item(cast(Any, movie))]
+    stub_client._map_results = [
+        (movie, (movie,), SyncTarget(list_media_key="m1", entry=entry))
+    ]
+    provider.entries["m1"] = entry
+
+    outcome = await stub_client.sync_media(
+        item=movie,
+        child_item=movie,
+        grandchild_items=(movie,),
+        entry=entry,
+        list_media_key="m1",
+    )
+
+    assert outcome == SyncOutcome.SYNCED
+    assert entry.status == ListStatus.REPEATING
+
+
+@pytest.mark.asyncio
+async def test_auto_rewatch_preserves_repeating_when_already_repeating(
+    stub_client: StubSyncClient, sync_db
+) -> None:
+    """auto_rewatch=True should keep REPEATING when entry is already REPEATING."""
+    stub_client.auto_rewatch = True
+    stub_client._status_override = ListStatus.CURRENT
+    stub_client._progress_override = 3
+
+    provider = cast(Any, stub_client.list_provider)
+    movie = make_movie()
+    entry = FakeListEntry(
+        provider=provider,
+        key="m1",
+        title="Movie",
+        media_type=ListMediaType.MOVIE,
+    )
+    entry.status = ListStatus.REPEATING
+    entry.progress = 1
+
+    stub_client._trackable_items = [ItemIdentifier.from_item(cast(Any, movie))]
+    stub_client._map_results = [
+        (movie, (movie,), SyncTarget(list_media_key="m1", entry=entry))
+    ]
+    provider.entries["m1"] = entry
+
+    outcome = await stub_client.sync_media(
+        item=movie,
+        child_item=movie,
+        grandchild_items=(movie,),
+        entry=entry,
+        list_media_key="m1",
+    )
+
+    assert outcome == SyncOutcome.SYNCED
+    assert entry.status == ListStatus.REPEATING
+    assert entry.progress == 3
+
+
+@pytest.mark.asyncio
+async def test_auto_rewatch_disabled_does_not_change_current(
+    stub_client: StubSyncClient, sync_db
+) -> None:
+    """auto_rewatch=False (default) should not promote CURRENT to REPEATING even when the existing entry is COMPLETED."""
+    stub_client.auto_rewatch = False
+    stub_client._status_override = ListStatus.CURRENT
+
+    provider = cast(Any, stub_client.list_provider)
+    movie = make_movie()
+    entry = FakeListEntry(
+        provider=provider,
+        key="m1",
+        title="Movie",
+        media_type=ListMediaType.MOVIE,
+    )
+    entry.status = ListStatus.COMPLETED
+
+    stub_client._trackable_items = [ItemIdentifier.from_item(cast(Any, movie))]
+    stub_client._map_results = [
+        (movie, (movie,), SyncTarget(list_media_key="m1", entry=entry))
+    ]
+    provider.entries["m1"] = entry
+
+    outcome = await stub_client.sync_media(
+        item=movie,
+        child_item=movie,
+        grandchild_items=(movie,),
+        entry=entry,
+        list_media_key="m1",
+    )
+
+    assert outcome == SyncOutcome.SYNCED
+    assert entry.status == ListStatus.CURRENT

--- a/tests/core/sync/test_base_client.py
+++ b/tests/core/sync/test_base_client.py
@@ -996,11 +996,11 @@ async def test_process_media_skips_untrackable_items(
 
 
 @pytest.mark.asyncio
-async def test_auto_rewatch_promotes_current_to_repeating_when_completed(
+async def test_promote_rewatch_promotes_current_to_repeating_when_completed(
     stub_client: StubSyncClient, sync_db
 ) -> None:
-    """auto_rewatch=True should change CURRENT to REPEATING when entry is COMPLETED."""
-    stub_client.auto_rewatch = True
+    """promote_rewatch=True changes CURRENT to REPEATING if COMPLETED."""
+    stub_client.promote_rewatch = True
     stub_client._status_override = ListStatus.CURRENT
 
     provider = cast(Any, stub_client.list_provider)
@@ -1032,11 +1032,11 @@ async def test_auto_rewatch_promotes_current_to_repeating_when_completed(
 
 
 @pytest.mark.asyncio
-async def test_auto_rewatch_preserves_repeating_when_already_repeating(
+async def test_promote_rewatch_preserves_repeating_when_already_repeating(
     stub_client: StubSyncClient, sync_db
 ) -> None:
-    """auto_rewatch=True should keep REPEATING when entry is already REPEATING."""
-    stub_client.auto_rewatch = True
+    """promote_rewatch=True should keep REPEATING when entry is already REPEATING."""
+    stub_client.promote_rewatch = True
     stub_client._status_override = ListStatus.CURRENT
     stub_client._progress_override = 3
 
@@ -1071,11 +1071,11 @@ async def test_auto_rewatch_preserves_repeating_when_already_repeating(
 
 
 @pytest.mark.asyncio
-async def test_auto_rewatch_disabled_does_not_change_current(
+async def test_promote_rewatch_disabled_does_not_change_current(
     stub_client: StubSyncClient, sync_db
 ) -> None:
-    """auto_rewatch=False (default) should not promote CURRENT to REPEATING even when the existing entry is COMPLETED."""
-    stub_client.auto_rewatch = False
+    """promote_rewatch=False should not promote CURRENT to REPEATING."""
+    stub_client.promote_rewatch = False
     stub_client._status_override = ListStatus.CURRENT
 
     provider = cast(Any, stub_client.list_provider)
@@ -1087,6 +1087,84 @@ async def test_auto_rewatch_disabled_does_not_change_current(
         media_type=ListMediaType.MOVIE,
     )
     entry.status = ListStatus.COMPLETED
+
+    stub_client._trackable_items = [ItemIdentifier.from_item(cast(Any, movie))]
+    stub_client._map_results = [
+        (movie, (movie,), SyncTarget(list_media_key="m1", entry=entry))
+    ]
+    provider.entries["m1"] = entry
+
+    outcome = await stub_client.sync_media(
+        item=movie,
+        child_item=movie,
+        grandchild_items=(movie,),
+        entry=entry,
+        list_media_key="m1",
+    )
+
+    assert outcome == SyncOutcome.SYNCED
+    assert entry.status == ListStatus.CURRENT
+
+
+@pytest.mark.asyncio
+async def test_promote_rewatch_respects_sync_fields_repeating_disabled(
+    stub_client: StubSyncClient, sync_db
+) -> None:
+    """sync_fields.status.repeating=False should block promote_rewatch promotion."""
+    stub_client.promote_rewatch = True
+    stub_client.sync_fields = {"status": {"repeating": False}}
+    stub_client._status_override = ListStatus.CURRENT
+
+    provider = cast(Any, stub_client.list_provider)
+    movie = make_movie()
+    entry = FakeListEntry(
+        provider=provider,
+        key="m1",
+        title="Movie",
+        media_type=ListMediaType.MOVIE,
+    )
+    entry.status = ListStatus.COMPLETED
+
+    stub_client._trackable_items = [ItemIdentifier.from_item(cast(Any, movie))]
+    stub_client._map_results = [
+        (movie, (movie,), SyncTarget(list_media_key="m1", entry=entry))
+    ]
+    provider.entries["m1"] = entry
+
+    await stub_client.sync_media(
+        item=movie,
+        child_item=movie,
+        grandchild_items=(movie,),
+        entry=entry,
+        list_media_key="m1",
+    )
+
+    # Promotion to REPEATING is blocked by sync_fields, so status stays COMPLETED
+    # Other fields may still sync, so outcome can be SYNCED
+    assert entry.status == ListStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "initial_status",
+    [ListStatus.PLANNING, ListStatus.DROPPED, ListStatus.PAUSED],
+)
+async def test_promote_rewatch_does_not_affect_non_completed_statuses(
+    stub_client: StubSyncClient, sync_db, initial_status: ListStatus
+) -> None:
+    """promote_rewatch should only apply when entry was COMPLETED or REPEATING."""
+    stub_client.promote_rewatch = True
+    stub_client._status_override = ListStatus.CURRENT
+
+    provider = cast(Any, stub_client.list_provider)
+    movie = make_movie()
+    entry = FakeListEntry(
+        provider=provider,
+        key="m1",
+        title="Movie",
+        media_type=ListMediaType.MOVIE,
+    )
+    entry.status = initial_status
 
     stub_client._trackable_items = [ItemIdentifier.from_item(cast(Any, movie))]
     stub_client._map_results = [

--- a/tests/core/test_bridge.py
+++ b/tests/core/test_bridge.py
@@ -220,7 +220,7 @@ def _make_profile_config(**overrides: Any) -> SimpleNamespace:
         "batch_requests": False,
         "backup_retention_days": -1,
         "dry_run": False,
-        "auto_rewatch": False,
+        "promote_rewatch": False,
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)

--- a/tests/core/test_bridge.py
+++ b/tests/core/test_bridge.py
@@ -220,6 +220,7 @@ def _make_profile_config(**overrides: Any) -> SimpleNamespace:
         "batch_requests": False,
         "backup_retention_days": -1,
         "dry_run": False,
+        "auto_rewatch": False,
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)


### PR DESCRIPTION
### Description

Adds an opt-in auto_rewatch profile option that automatically promotes the list status to Repeating when watch activity is detected in the library for an entry that is already marked as Completed (or manually set to Repeating) on the list provider. Without this option, starting to rewatch content that was previously completed would incorrectly overwrite the Completed status with Current.

**What's new:**
- New auto_rewatch profile config option (default: false). When enabled, if a sync calculates a CURRENT status for an entry that is already COMPLETED or REPEATING on the list provider, the status is promoted to REPEATING instead. This covers two scenarios:
    - Downloading and starting to watch an anime in Plex that was already marked as completed on AniList -- the first episode update will correctly mark the show as rewatching and continue tracking progress.
    - Manually setting a show to rewatching on AniList -- subsequent progress updates from Plex will continue to sync correctly without reverting the status to current.

### Database Migration

NO - ###

### Checklist

- [X] I have performed a self-review of my own code
- [X] My code passes the test suite (`pytest`)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [X] I have commented my code, particularly in hard-to-understand areas