### PR TITLE
Unobvious sync rules behavior

### DIFF
--- a/src/anibridge/app/config/sync_rules.py
+++ b/src/anibridge/app/config/sync_rules.py
@@ -322,7 +322,7 @@ class SyncRulesConfig(BaseModel):
         self,
         field_name: str,
     ) -> bool | list[SyncRuleDefinition]:
-        """Resolve one field's effective rule payload including templates."""
+        """Resolve one field's effective rule payload with user-first priority."""
         template_value = self._template_field_value(field_name)
         user_value = cast(bool | list[SyncRuleDefinition], getattr(self, field_name))
         user_explicit = field_name in self.model_fields_set
@@ -334,7 +334,7 @@ class SyncRulesConfig(BaseModel):
         if user_value is True:
             return template_value if template_value is not None else True
         if isinstance(template_value, list):
-            return [*template_value, *user_value]
+            return [*user_value, *template_value]
         return user_value
 
     def _template_field_value(

--- a/src/anibridge/app/config/sync_rules.py
+++ b/src/anibridge/app/config/sync_rules.py
@@ -68,8 +68,7 @@ class SyncRuleDefinition(BaseModel):
         alias="if",
         description="Condition expression evaluated against the sync context",
     )
-    set_expr: Any | None = Field(
-        default=None,
+    set_expr: Any = Field(
         alias="set",
         description="Expression or literal value returned when the rule matches",
     )
@@ -87,8 +86,8 @@ class SyncRuleDefinition(BaseModel):
 
     @field_validator("set_expr")
     @classmethod
-    def validate_set_expr(cls, value: Any | None) -> Any | None:
-        """Validate the optional set expression when it is string-based."""
+    def validate_set_expr(cls, value: Any) -> Any:
+        """Validate the required set expression when it is string-based."""
         if isinstance(value, str):
             if not value.strip():
                 raise ValueError("sync rule set expressions cannot be blank")
@@ -167,10 +166,12 @@ SYNC_RULE_TEMPLATES: Final[dict[SyncRuleTemplateId, SyncRuleTemplate]] = {
     SyncRuleTemplateId.DISABLE_DROPPED_AND_PAUSED: SyncRuleTemplate(
         description="Map dropped and paused statuses to current.",
         status=[
-            SyncRuleDefinition(
-                name="Disable dropped status syncing",
-                if_expr='computed.status in ("dropped", "paused")',
-                set_expr='"current" if current.status is None else current.status',
+            SyncRuleDefinition.model_validate(
+                {
+                    "name": "Don't sync dropped or paused status changes",
+                    "if": 'computed.status in ("dropped", "paused")',
+                    "set": '"current" if current.status is None else current.status',
+                }
             ),
         ],
     ),
@@ -185,56 +186,67 @@ SYNC_RULE_TEMPLATES: Final[dict[SyncRuleTemplateId, SyncRuleTemplate]] = {
             "backward by keeping the current list value instead."
         ),
         status=[
-            SyncRuleDefinition(
-                name="Keep non-regressing status",
-                if_expr=(
-                    "current.status is not None and "
-                    "(computed.status is None or computed.status < current.status)"
-                ),
-                set_expr="current.status",
+            SyncRuleDefinition.model_validate(
+                {
+                    "name": "Prevent regressing status",
+                    "if": (
+                        "current.status is not None and "
+                        "(computed.status is None or computed.status < current.status)"
+                    ),
+                    "set": "current.status",
+                }
             )
         ],
         progress=[
-            SyncRuleDefinition(
-                name="Keep non-regressing progress",
-                if_expr=(
-                    "current.progress is not None and "
-                    "(computed.progress is None or "
-                    "computed.progress < current.progress)"
-                ),
-                set_expr="current.progress",
+            SyncRuleDefinition.model_validate(
+                {
+                    "name": "Prevent regressing progress",
+                    "if": (
+                        "current.progress is not None and "
+                        "(computed.progress is None or "
+                        "computed.progress < current.progress)"
+                    ),
+                    "set": "current.progress",
+                }
             )
         ],
         repeats=[
-            SyncRuleDefinition(
-                name="Keep non-regressing repeats",
-                if_expr=(
-                    "current.repeats is not None and "
-                    "(computed.repeats is None or computed.repeats < current.repeats)"
-                ),
-                set_expr="current.repeats",
+            SyncRuleDefinition.model_validate(
+                {
+                    "name": "Prevent regressing repeats",
+                    "if": (
+                        "current.repeats is not None and "
+                        "(computed.repeats is None or "
+                        "computed.repeats < current.repeats)"
+                    ),
+                    "set": "current.repeats",
+                }
             )
         ],
         started_at=[
-            SyncRuleDefinition(
-                name="Keep non-regressing started_at",
-                if_expr=(
-                    "current.started_at is not None and "
-                    "(computed.started_at is None or "
-                    "computed.started_at < current.started_at)"
-                ),
-                set_expr="current.started_at",
+            SyncRuleDefinition.model_validate(
+                {
+                    "name": "Prevent regressing started_at",
+                    "if": (
+                        "current.started_at is not None and "
+                        "(computed.started_at is None or "
+                        "computed.started_at < current.started_at)"
+                    ),
+                    "set": "current.started_at",
+                }
             )
         ],
         finished_at=[
-            SyncRuleDefinition(
-                name="Keep non-regressing finished_at",
-                if_expr=(
-                    "current.finished_at is not None and "
-                    "(computed.finished_at is None or "
-                    "computed.finished_at < current.finished_at)"
-                ),
-                set_expr="current.finished_at",
+            SyncRuleDefinition.model_validate(
+                {
+                    "name": "Prevent regressing finished_at",
+                    "if": (
+                        "current.finished_at is not None and "
+                        "(computed.finished_at is None or "
+                        "computed.finished_at < current.finished_at)"
+                    ),
+                    "set": "current.finished_at",
+                }
             )
         ],
     ),
@@ -244,13 +256,15 @@ SYNC_RULE_TEMPLATES: Final[dict[SyncRuleTemplateId, SyncRuleTemplate]] = {
             "activity computes a current status."
         ),
         status=[
-            SyncRuleDefinition(
-                name="Promote rewatch to repeating",
-                if_expr=(
-                    'current.status in ("completed", "repeating") and '
-                    'computed.status == "current"'
-                ),
-                set_expr="repeating",
+            SyncRuleDefinition.model_validate(
+                {
+                    "name": "Promote rewatch to repeating",
+                    "if": (
+                        'current.status in ("completed", "repeating") and '
+                        'computed.status == "current"'
+                    ),
+                    "set": "repeating",
+                }
             )
         ],
     ),

--- a/src/anibridge/app/config/sync_rules.py
+++ b/src/anibridge/app/config/sync_rules.py
@@ -164,7 +164,10 @@ class SyncRuleTemplateId(BaseStrEnum):
 
 SYNC_RULE_TEMPLATES: Final[dict[SyncRuleTemplateId, SyncRuleTemplate]] = {
     SyncRuleTemplateId.DISABLE_DROPPED_AND_PAUSED: SyncRuleTemplate(
-        description="Map dropped and paused statuses to current.",
+        description=(
+            "Prevent dropped and paused computed statuses from replacing the "
+            "current list status."
+        ),
         status=[
             SyncRuleDefinition.model_validate(
                 {
@@ -276,7 +279,7 @@ class SyncRulesConfig(BaseModel):
 
     templates: list[SyncRuleTemplateId] = Field(
         default_factory=lambda: [SyncRuleTemplateId.DISABLE_USER_RATING_AND_REVIEW],
-        description="Built-in templates to apply in order before user-defined rules",
+        description="Built-in templates to apply in order after the user-defined rules",
     )
     vars: dict[str, str] = Field(
         default_factory=dict,

--- a/src/anibridge/app/core/sync/rules.py
+++ b/src/anibridge/app/core/sync/rules.py
@@ -298,7 +298,7 @@ class SyncRuleEngine:
         computed_values: Mapping[str, Any],
         rule_context: Mapping[str, Any] | None = None,
     ) -> SyncRuleDecision:
-        """Resolve the effective value for one field against the sync context.
+        """Resolve one field using first-match wins with default fallback.
 
         Args:
             field_name (str): Sync field name being evaluated.
@@ -344,7 +344,7 @@ class SyncRuleEngine:
             rule_name = str(rule.get("name") or f"rule_{index}")
             return SyncRuleDecision(allowed=True, value=value, reason=rule_name)
 
-        return SyncRuleDecision(allowed=False, value=current_value, reason="no_match")
+        return SyncRuleDecision(allowed=True, value=computed_value, reason="default")
 
     def _build_environment(
         self,

--- a/src/anibridge/app/core/sync/rules.py
+++ b/src/anibridge/app/core/sync/rules.py
@@ -336,10 +336,12 @@ class SyncRuleEngine:
             ):
                 continue
 
-            if "set" in rule:
-                value = self._resolve_set_value(field_name, rule["set"], environment)
-            else:
-                value = computed_value
+            if "set" not in rule:
+                raise ValueError(
+                    f"sync rule {index} for field {field_name!r} is missing "
+                    "required 'set'"
+                )
+            value = self._resolve_set_value(field_name, rule["set"], environment)
 
             rule_name = str(rule.get("name") or f"rule_{index}")
             return SyncRuleDecision(allowed=True, value=value, reason=rule_name)

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -197,8 +197,8 @@ def test_sync_rules_accept_declarative_field_rules() -> None:
     assert review_rules[0]["set"] is None
 
 
-def test_sync_rules_templates_prepend_selected_rules() -> None:
-    """Built-in templates should prepend field rules before user-defined rules."""
+def test_sync_rules_user_rules_precede_template_rules() -> None:
+    """User field rules should run before built-in template fallback rules."""
     rules = SyncRulesConfig.model_validate(
         {
             "templates": [SyncRuleTemplateId.PROMOTE_REWATCH],
@@ -206,7 +206,7 @@ def test_sync_rules_templates_prepend_selected_rules() -> None:
                 {
                     "name": "User rule",
                     "if": "computed.status == current.status",
-                    "set": "computed.status",
+                    "set": "current.status",
                 }
             ],
         }
@@ -214,8 +214,42 @@ def test_sync_rules_templates_prepend_selected_rules() -> None:
 
     status_rules = cast(list[dict[str, object]], rules.field_rules()["status"])
 
+    assert status_rules[0]["name"] == "User rule"
+    assert status_rules[1]["name"] == "Promote rewatch to repeating"
+
+
+def test_sync_rules_disable_dropped_and_paused_template_adds_status_guard() -> None:
+    """Dropped/paused template should add the expected status guard rule."""
+    rules = SyncRulesConfig.model_validate(
+        {
+            "templates": [SyncRuleTemplateId.DISABLE_DROPPED_AND_PAUSED],
+        }
+    )
+
+    status_rules = cast(list[dict[str, object]], rules.field_rules()["status"])
+
+    assert status_rules[0]["name"] == "Don't sync dropped or paused status changes"
+    assert status_rules[0]["if"] == 'computed.status in ("dropped", "paused")'
+    assert status_rules[0]["set"] == (
+        '"current" if current.status is None else current.status'
+    )
+
+
+def test_sync_rules_promote_rewatch_template_adds_status_promotion_rule() -> None:
+    """Promote rewatch template should add the status promotion rule."""
+    rules = SyncRulesConfig.model_validate(
+        {
+            "templates": [SyncRuleTemplateId.PROMOTE_REWATCH],
+        }
+    )
+
+    status_rules = cast(list[dict[str, object]], rules.field_rules()["status"])
+
     assert status_rules[0]["name"] == "Promote rewatch to repeating"
-    assert status_rules[1]["name"] == "User rule"
+    assert status_rules[0]["if"] == (
+        'current.status in ("completed", "repeating") and computed.status == "current"'
+    )
+    assert status_rules[0]["set"] == "repeating"
 
 
 def test_sync_rules_disable_review_and_rating_template_overrides_defaults() -> None:
@@ -280,6 +314,20 @@ def test_sync_rules_reject_none_field_values() -> None:
         SyncRulesConfig.model_validate({"status": None})
 
 
+def test_sync_rules_reject_rule_without_set() -> None:
+    """Declarative sync rules must provide an explicit set value."""
+    with pytest.raises(ValueError):
+        SyncRulesConfig.model_validate(
+            {
+                "review": [
+                    {
+                        "if": "computed.review is not None",
+                    }
+                ]
+            }
+        )
+
+
 def test_sync_rules_reject_invalid_variable_names() -> None:
     """sync_rules.vars names must be safe Python identifiers."""
     with pytest.raises(ValueError):
@@ -294,6 +342,7 @@ def test_sync_rules_reject_unsupported_expression_syntax() -> None:
                 "review": [
                     {
                         "if": "[value for value in [1, 2, 3]]",
+                        "set": None,
                     }
                 ]
             }

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import cast
 
 import pytest
+import yaml
 from pydantic import SecretStr
 
 from anibridge.app.config.settings import (
@@ -16,6 +17,7 @@ from anibridge.app.config.settings import (
     WebConfig,
     find_yaml_config_file,
 )
+from anibridge.app.core.sync.rules import SyncRuleEngine
 from anibridge.app.exceptions import (
     ProfileConfigError,
     ProfileNotFoundError,
@@ -347,6 +349,42 @@ def test_sync_rules_reject_unsupported_expression_syntax() -> None:
                 ]
             }
         )
+
+
+@pytest.mark.parametrize(
+    ("yaml_set_value", "expected_rule_set"),
+    [("null", None), ("None", "None")],
+)
+def test_sync_rules_yaml_set_values_preserve_null_and_none_semantics(
+    yaml_set_value: str,
+    expected_rule_set: object,
+) -> None:
+    """YAML null and bare None should preserve their expected sync-rule meaning."""
+    payload = yaml.safe_load(
+        "global_config:\n"
+        "  sync_rules:\n"
+        "    review:\n"
+        "      - name: Clear review\n"
+        f"        set: {yaml_set_value}\n"
+    )
+
+    rules = SyncRulesConfig.model_validate(payload["global_config"]["sync_rules"])
+    review_rules = cast(list[dict[str, object]], rules.field_rules()["review"])
+
+    assert review_rules[0]["set"] == expected_rule_set
+
+    decision = SyncRuleEngine(
+        variables=rules.resolved_vars(),
+        field_rules=rules.field_rules(),
+    ).evaluate_field(
+        field_name="review",
+        current_values={"review": "existing"},
+        computed_values={"review": "computed"},
+    )
+
+    assert decision.allowed is True
+    assert decision.value is None
+    assert decision.reason == "Clear review"
 
 
 def test_web_config_reports_auth_configuration_state(tmp_path: Path) -> None:

--- a/tests/core/sync/test_base_client.py
+++ b/tests/core/sync/test_base_client.py
@@ -747,8 +747,9 @@ async def test_sync_media_info_reports_rule_and_status_blocks(
         {
             "progress": [
                 {
-                    "name": "Only allow non-increasing progress",
-                    "if": "computed.progress <= current.progress",
+                    "name": "Freeze progress if status is planning",
+                    "if": "current.status == 'planning'",
+                    "set": "current.progress",
                 }
             ],
             "review": False,
@@ -767,7 +768,7 @@ async def test_sync_media_info_reports_rule_and_status_blocks(
     with sync_db as ctx:
         record = ctx.session.query(SyncHistory).one()
         assert record.info is not None
-        assert "progress(no_match)" in (record.info.get("sync_rules_blocked") or "")
+        assert "progress(no_match)" not in (record.info.get("sync_rules_blocked") or "")
         assert "review" in (record.info.get("disabled_fields") or "")
         assert "user_rating(requires_completed)" in (
             record.info.get("status_gate_blocked") or ""
@@ -1002,10 +1003,10 @@ async def test_sync_media_exposes_ctx_item_child_and_grandchildren(
 
 
 @pytest.mark.asyncio
-async def test_sync_media_blocks_field_when_no_sync_rule_matches(
+async def test_sync_media_uses_default_value_when_no_sync_rule_matches(
     stub_client: StubSyncClient,
 ) -> None:
-    """Configured field rules should block sync when nothing matches."""
+    """Configured field rules should fall back to computed values when unmatched."""
     provider = cast(FakeListProvider, stub_client.list_provider)
     movie = make_movie(review="x" * 220)
     entry = FakeListEntry(
@@ -1035,8 +1036,9 @@ async def test_sync_media_blocks_field_when_no_sync_rule_matches(
             },
             "review": [
                 {
-                    "name": "Only sync short reviews",
+                    "name": "Tag short reviews",
                     "if": "vars.has_short_review",
+                    "set": 'computed.review + " [short]"',
                 }
             ],
         },
@@ -1050,9 +1052,9 @@ async def test_sync_media_blocks_field_when_no_sync_rule_matches(
         list_media_key="rule-blocked",
     )
 
-    assert result is SyncOutcome.SKIPPED
-    assert entry.review == "existing"
-    assert provider.updated_entries == []
+    assert result is SyncOutcome.SYNCED
+    assert entry.review == "x" * 220
+    assert provider.updated_entries and provider.updated_entries[0][0] == "rule-blocked"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Description

The previous sync-rule system technically worked, but its behavior was unintuitive:

- Rule precedence was not obvious.
- Unmatched rules (no `if` condition matched) could produce surprising behavior by skipping the entire field.
- Because every rule got executed (no early exit), it can become very hard to track why a certain outcome was reached.
- Some rule definitions were effectively no-ops.

The change is easiest to think of as moving from independent `if` checks to an `elif` chain.

Before:

```py
if: A
if: B
if: C
```

After:

```py
if: A
elif: B
elif: C
```

In practice, rules are now evaluated in order with first-match behavior, and unmatched cases fall back to the computed value.

### Improvements

- Rule evaluation now uses a first-match design.
- Unmatched rule sets now default to computed field values instead of blocking field sync.
- Template behavior is more predictable when combined with user rules.

### Fixes

- Certain sync rules templates being no-ops

### Issues Fixed or Closed by this PR

- Closes #223

### Checklist

- [x] I have performed a self-review of my own code
- [x] My code passes the test suite (`pytest`)
- [x] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas