### PR TITLE
Mapping ratios

### DIFF
--- a/src/anibridge/app/core/sync/base.py
+++ b/src/anibridge/app/core/sync/base.py
@@ -24,7 +24,11 @@ from anibridge.app.core.sync.stats import (
     ItemIdentifier,
     SyncStats,
 )
-from anibridge.app.core.sync.targeting import SyncTarget, diff_snapshots
+from anibridge.app.core.sync.targeting import (
+    SourceRangeMapping,
+    SyncTarget,
+    diff_snapshots,
+)
 from anibridge.app.models.db.sync_history import SyncOutcome
 from anibridge.app.utils.terminal import ARROW
 
@@ -224,6 +228,7 @@ class BaseSyncClient[
                     entry=entry,
                     list_media_key=list_media_key,
                     mapping_descriptors=target.mapping_descriptors,
+                    source_mappings=target.source_mappings,
                 )
                 self.sync_stats.track_items(grandchild_ids, outcome)
                 self.sync_stats.track_item(item_identifier, outcome)
@@ -323,6 +328,7 @@ class BaseSyncClient[
         entry: ListEntry,
         list_media_key: str | None,
         mapping_descriptors: Sequence[MappingDescriptor] | None = None,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> SyncOutcome:
         """Synchronize a mapped media item with the list provider.
 
@@ -335,6 +341,8 @@ class BaseSyncClient[
             list_media_key (str | None): Resolved list media key for the target entry.
             mapping_descriptors (Sequence[MappingDescriptor] | None): Mapping
                 descriptors used to find the target.
+            source_mappings (Sequence[SourceRangeMapping] | None): Source mapping
+                ranges used to resolve the target.
 
         Returns:
             SyncOutcome: Final outcome for the sync operation.
@@ -362,6 +370,7 @@ class BaseSyncClient[
             "child_item": child_item,
             "grandchild_items": grandchild_items,
             "entry": entry,
+            "source_mappings": source_mappings,
         }
         computed_values = await self._calculate_computed_values(
             calc_kwargs=calc_kwargs, disabled_fields=disabled_fields
@@ -921,6 +930,7 @@ class BaseSyncClient[
         child_item: ChildMediaT,
         grandchild_items: Sequence[GrandchildMediaT],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> ListStatus | None:
         """Calculate the desired status for the list entry."""
         ...
@@ -933,6 +943,7 @@ class BaseSyncClient[
         child_item: ChildMediaT,
         grandchild_items: Sequence[GrandchildMediaT],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> int | None:
         """Calculate the desired score for the list entry."""
         ...
@@ -945,6 +956,7 @@ class BaseSyncClient[
         child_item: ChildMediaT,
         grandchild_items: Sequence[GrandchildMediaT],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> int | None:
         """Calculate the desired progress for the list entry."""
         ...
@@ -957,6 +969,7 @@ class BaseSyncClient[
         child_item: ChildMediaT,
         grandchild_items: Sequence[GrandchildMediaT],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> int | None:
         """Calculate the desired repeat count for the list entry."""
         ...
@@ -969,6 +982,7 @@ class BaseSyncClient[
         child_item: ChildMediaT,
         grandchild_items: Sequence[GrandchildMediaT],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> datetime | None:
         """Calculate the desired start date for the list entry."""
         ...
@@ -981,6 +995,7 @@ class BaseSyncClient[
         child_item: ChildMediaT,
         grandchild_items: Sequence[GrandchildMediaT],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> datetime | None:
         """Calculate the desired completion date for the list entry."""
         ...
@@ -993,6 +1008,7 @@ class BaseSyncClient[
         child_item: ChildMediaT,
         grandchild_items: Sequence[GrandchildMediaT],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> str | None:
         """Calculate the desired review/notes for the list entry."""
         ...

--- a/src/anibridge/app/core/sync/movie.py
+++ b/src/anibridge/app/core/sync/movie.py
@@ -11,6 +11,7 @@ from anibridge.app.core.animap import descriptor_key
 from anibridge.app.core.sync.base import BaseSyncClient
 from anibridge.app.core.sync.stats import ItemIdentifier
 from anibridge.app.core.sync.targeting import (
+    SourceRangeMapping,
     SyncTarget,
     find_best_search_result,
     resolve_list_targets,
@@ -60,6 +61,7 @@ class MovieSyncClient(BaseSyncClient[LibraryMovie, LibraryMovie, LibraryMovie]):
                         list_media_key=list_media_key,
                         entry=entry,
                         mapping_descriptors=target.mapping_descriptors,
+                        source_mappings=target.source_mappings,
                     ),
                 )
             if yielded:
@@ -129,6 +131,7 @@ class MovieSyncClient(BaseSyncClient[LibraryMovie, LibraryMovie, LibraryMovie]):
         child_item: LibraryMovie,
         grandchild_items: Sequence[LibraryMovie],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> ListStatus | None:
         has_views = item.view_count > 0
         history = await self._get_history(item)
@@ -155,6 +158,7 @@ class MovieSyncClient(BaseSyncClient[LibraryMovie, LibraryMovie, LibraryMovie]):
         child_item: LibraryMovie,
         grandchild_items: Sequence[LibraryMovie],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> int | None:
         return item.user_rating
 
@@ -165,6 +169,7 @@ class MovieSyncClient(BaseSyncClient[LibraryMovie, LibraryMovie, LibraryMovie]):
         child_item: LibraryMovie,
         grandchild_items: Sequence[LibraryMovie],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> int | None:
         total_units = entry.media().total_units or len(grandchild_items) or 1
         return total_units if item.view_count > 0 else None
@@ -176,6 +181,7 @@ class MovieSyncClient(BaseSyncClient[LibraryMovie, LibraryMovie, LibraryMovie]):
         child_item: LibraryMovie,
         grandchild_items: Sequence[LibraryMovie],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> int | None:
         return item.view_count - 1 if item.view_count > 0 else None
 
@@ -186,6 +192,7 @@ class MovieSyncClient(BaseSyncClient[LibraryMovie, LibraryMovie, LibraryMovie]):
         child_item: LibraryMovie,
         grandchild_items: Sequence[LibraryMovie],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> datetime | None:
         history = await self._get_history(item)
         if not history:
@@ -199,6 +206,7 @@ class MovieSyncClient(BaseSyncClient[LibraryMovie, LibraryMovie, LibraryMovie]):
         child_item: LibraryMovie,
         grandchild_items: Sequence[LibraryMovie],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> datetime | None:
         history = await self._get_history(item)
         if not history:
@@ -212,6 +220,7 @@ class MovieSyncClient(BaseSyncClient[LibraryMovie, LibraryMovie, LibraryMovie]):
         child_item: LibraryMovie,
         grandchild_items: Sequence[LibraryMovie],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> str | None:
         return await item.review
 

--- a/src/anibridge/app/core/sync/show.py
+++ b/src/anibridge/app/core/sync/show.py
@@ -441,6 +441,7 @@ class ShowSyncClient(BaseSyncClient[LibraryShow, LibrarySeason, LibraryEpisode])
             return item.user_rating
         return None
 
+    @lru_cache(maxsize=1)  # De-duplicate call from status
     async def _calculate_progress(
         self,
         *,

--- a/src/anibridge/app/core/sync/show.py
+++ b/src/anibridge/app/core/sync/show.py
@@ -164,6 +164,7 @@ class ShowSyncClient(BaseSyncClient[LibraryShow, LibrarySeason, LibraryEpisode])
                     list_media_key=group.media_key,
                     entry=group.entry,
                     mapping_descriptors=tuple(group.mapping_descriptors),
+                    source_mappings=tuple(group.source_mappings),
                 ),
             )
 
@@ -368,6 +369,7 @@ class ShowSyncClient(BaseSyncClient[LibraryShow, LibrarySeason, LibraryEpisode])
         child_item: LibrarySeason,
         grandchild_items: Sequence[LibraryEpisode],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> ListStatus | None:
         watched_count = len(
             [episode for episode in grandchild_items if episode.view_count]
@@ -423,6 +425,7 @@ class ShowSyncClient(BaseSyncClient[LibraryShow, LibrarySeason, LibraryEpisode])
         child_item: LibrarySeason,
         grandchild_items: Sequence[LibraryEpisode],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> int | None:
         scores = [
             episode.user_rating for episode in grandchild_items if episode.user_rating
@@ -442,6 +445,7 @@ class ShowSyncClient(BaseSyncClient[LibraryShow, LibrarySeason, LibraryEpisode])
         child_item: LibrarySeason,
         grandchild_items: Sequence[LibraryEpisode],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> int | None:
         watched = len([episode for episode in grandchild_items if episode.view_count])
         total_units = entry.media().total_units or len(grandchild_items)
@@ -456,6 +460,7 @@ class ShowSyncClient(BaseSyncClient[LibraryShow, LibrarySeason, LibraryEpisode])
         child_item: LibrarySeason,
         grandchild_items: Sequence[LibraryEpisode],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> int | None:
         view_counts = [
             episode.view_count for episode in grandchild_items if episode.view_count
@@ -469,6 +474,7 @@ class ShowSyncClient(BaseSyncClient[LibraryShow, LibrarySeason, LibraryEpisode])
         child_item: LibrarySeason,
         grandchild_items: Sequence[LibraryEpisode],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> datetime | None:
         history = await self._filter_history_by_episodes(item, grandchild_items)
         if not history:
@@ -482,6 +488,7 @@ class ShowSyncClient(BaseSyncClient[LibraryShow, LibrarySeason, LibraryEpisode])
         child_item: LibrarySeason,
         grandchild_items: Sequence[LibraryEpisode],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> datetime | None:
         history = await self._filter_history_by_episodes(item, grandchild_items)
         if not history:
@@ -495,6 +502,7 @@ class ShowSyncClient(BaseSyncClient[LibraryShow, LibrarySeason, LibraryEpisode])
         child_item: LibrarySeason,
         grandchild_items: Sequence[LibraryEpisode],
         entry: ListEntry,
+        source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> str | None:
         if entry.media().total_units == 1 and len(grandchild_items) == 1:
             review = await grandchild_items[0].review

--- a/src/anibridge/app/core/sync/show.py
+++ b/src/anibridge/app/core/sync/show.py
@@ -32,6 +32,7 @@ class _SeasonGroup:
     entry: ListEntry
     media_key: str
     mapping_descriptors: list[MappingDescriptor]
+    source_mappings: list[SourceRangeMapping]
 
 
 class ShowSyncClient(BaseSyncClient[LibraryShow, LibrarySeason, LibraryEpisode]):
@@ -144,6 +145,7 @@ class ShowSyncClient(BaseSyncClient[LibraryShow, LibrarySeason, LibraryEpisode])
                         entry=entry,
                         media_key=media_key,
                         mapping_descriptors=list(target.mapping_descriptors),
+                        source_mappings=list(target.source_mappings),
                     )
                     continue
 
@@ -154,6 +156,9 @@ class ShowSyncClient(BaseSyncClient[LibraryShow, LibrarySeason, LibraryEpisode])
                 for descriptor in target.mapping_descriptors:
                     if descriptor not in group.mapping_descriptors:
                         group.mapping_descriptors.append(descriptor)
+                for source_mapping in target.source_mappings:
+                    if source_mapping not in group.source_mappings:
+                        group.source_mappings.append(source_mapping)
 
         for group in sorted(groups.values(), key=lambda g: g.first_index):
             eps = sorted(group.episodes, key=lambda ep: (ep.season_index, ep.index))
@@ -371,9 +376,7 @@ class ShowSyncClient(BaseSyncClient[LibraryShow, LibrarySeason, LibraryEpisode])
         entry: ListEntry,
         source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> ListStatus | None:
-        watched_count = len(
-            [episode for episode in grandchild_items if episode.view_count]
-        )
+        watched_count = self._calculate_watched_units(grandchild_items, source_mappings)
         min_view_count = min(
             (episode.view_count for episode in grandchild_items if episode.view_count),
             default=0,
@@ -447,7 +450,7 @@ class ShowSyncClient(BaseSyncClient[LibraryShow, LibrarySeason, LibraryEpisode])
         entry: ListEntry,
         source_mappings: Sequence[SourceRangeMapping] | None = None,
     ) -> int | None:
-        watched = len([episode for episode in grandchild_items if episode.view_count])
+        watched = self._calculate_watched_units(grandchild_items, source_mappings)
         total_units = entry.media().total_units or len(grandchild_items)
         if total_units:
             return min(watched, total_units)
@@ -509,6 +512,53 @@ class ShowSyncClient(BaseSyncClient[LibraryShow, LibrarySeason, LibraryEpisode])
             if review:
                 return review
         return await child_item.review or await item.review
+
+    def _calculate_watched_units(
+        self,
+        episodes: Sequence[LibraryEpisode],
+        source_mappings: Sequence[SourceRangeMapping] | None,
+    ) -> int:
+        """Calculate the number of watched units, taking mapping ratios into account."""
+        watched_count = sum(1 for episode in episodes if episode.view_count)
+        if watched_count == 0:
+            return 0
+        if not source_mappings:
+            return watched_count
+
+        ranges = [
+            source_range
+            for mapping in source_mappings
+            for source_range in mapping.ranges
+        ]
+        if not ranges:
+            return watched_count
+        if all(
+            source_range.ratio is None or source_range.ratio == 1
+            for source_range in ranges
+        ):
+            # Basic case where there's no ratio weight
+            return watched_count
+
+        watched_units = 0.0
+        ratio_by_index: dict[int, int | None] = {}  # Cache
+        for episode in episodes:
+            if not episode.view_count:
+                continue
+            ratio = ratio_by_index.get(episode.index)
+            if episode.index not in ratio_by_index:
+                ratio = None
+                for source_range in ranges:
+                    if source_range.contains(episode.index):
+                        ratio = source_range.ratio
+                        break
+                ratio_by_index[episode.index] = ratio
+            if ratio is None or ratio == 1:
+                watched_units += 1
+            elif ratio > 0:
+                watched_units += ratio
+            else:
+                watched_units += 1 / abs(ratio)
+        return int(watched_units)
 
     def _debug_log_title(
         self,

--- a/src/anibridge/app/core/sync/targeting.py
+++ b/src/anibridge/app/core/sync/targeting.py
@@ -55,6 +55,7 @@ class SyncTarget:
     list_media_key: str
     entry: ListEntry
     mapping_descriptors: tuple[MappingDescriptor, ...] = ()
+    source_mappings: tuple[SourceRangeMapping, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/core/sync/test_show_client.py
+++ b/tests/core/sync/test_show_client.py
@@ -1079,6 +1079,76 @@ async def test_calculate_progress_and_repeats(
 
 
 @pytest.mark.asyncio
+async def test_calculate_progress_applies_positive_ratio(
+    show_client: ShowSyncClient,
+) -> None:
+    """Positive source ratios should scale watched progress upward."""
+    show, season, episodes = build_show(view_counts=[1, 1])
+    entry = FakeListEntry(
+        provider=FakeListProvider(),
+        key="entry",
+        title="Show",
+        media_type=ListMediaType.TV,
+        total_units=4,
+    )
+    source_mappings = (
+        SourceRangeMapping(
+            descriptor=("anilist", "1", None),
+            ranges=(SourceRange(start=1, end=2, ratio=2),),
+        ),
+    )
+
+    progress = await show_client._calculate_progress(
+        item=cast(LibraryShowProtocol, show),
+        child_item=cast(LibrarySeasonProtocol, season),
+        grandchild_items=cast(Sequence[LibraryEpisodeProtocol], tuple(episodes)),
+        entry=cast(ListEntryProtocol, entry),
+        source_mappings=source_mappings,
+    )
+    status = await show_client._calculate_status(
+        item=cast(LibraryShowProtocol, show),
+        child_item=cast(LibrarySeasonProtocol, season),
+        grandchild_items=cast(Sequence[LibraryEpisodeProtocol], tuple(episodes)),
+        entry=cast(ListEntryProtocol, entry),
+        source_mappings=source_mappings,
+    )
+
+    assert progress == 4
+    assert status == ListStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_calculate_progress_applies_negative_ratio(
+    show_client: ShowSyncClient,
+) -> None:
+    """Negative source ratios should scale watched progress downward."""
+    show, season, episodes = build_show(view_counts=[1, 1, 1])
+    entry = FakeListEntry(
+        provider=FakeListProvider(),
+        key="entry",
+        title="Show",
+        media_type=ListMediaType.TV,
+        total_units=3,
+    )
+    source_mappings = (
+        SourceRangeMapping(
+            descriptor=("anilist", "1", None),
+            ranges=(SourceRange(start=1, end=3, ratio=-2),),
+        ),
+    )
+
+    progress = await show_client._calculate_progress(
+        item=cast(LibraryShowProtocol, show),
+        child_item=cast(LibrarySeasonProtocol, season),
+        grandchild_items=cast(Sequence[LibraryEpisodeProtocol], tuple(episodes)),
+        entry=cast(ListEntryProtocol, entry),
+        source_mappings=source_mappings,
+    )
+
+    assert progress == 1
+
+
+@pytest.mark.asyncio
 async def test_calculate_started_finished_at(show_client: ShowSyncClient) -> None:
     """Start and finish timestamps should use min/max history values."""
     history = [


### PR DESCRIPTION
### Description

This PR adds support for more complicated mapping ranges that include a mapping ratio (see the [anibridge-mappings schema docs](https://github.com/anibridge/anibridge-mappings/tree/c0b04e557b05e8313e7e3376a172ed180c8bbf50?tab=readme-ov-file#mappings-schema) for more details).

Progress for these complicated mappings will now be correctly computed.

**What's new:**

- Implemented ratio-aware progress calculation

**Improvements:**

- Reduced repeated work for progress calculation which was previously called twice for each show

### Checklist

- [x] I have performed a self-review of my own code
- [x] My code passes the test suite (`pytest`)
- [x] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
