### PR TITLE
Cron intervals

### DIFF
--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -139,8 +139,8 @@ export interface ProfileConfig {
     list_namespace?: string;
     library_user?: string | null;
     list_user?: string | null;
-    scan_interval?: number | null;
-    poll_interval?: number | null;
+    scan_interval?: number | string | null;
+    poll_interval?: number | string | null;
     scan_modes?: string[];
     full_scan?: boolean | null;
     destructive_sync?: boolean | null;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "anibridge-utils>=0.2.0b2",
     "bcrypt>=5.0.0",
     "colorama>=0.4.6",
+    "croniter>=6.2.2",
     "fastapi[standard-no-fastapi-cloud-cli]>=0.133.1",
     "orjson>=3.11.7",
     "pydantic-settings>=2.13.1",

--- a/src/anibridge/app/config/settings.py
+++ b/src/anibridge/app/config/settings.py
@@ -24,11 +24,13 @@ from anibridge.app.config.sync_rules import (
     SyncRuleTemplateId,
 )
 from anibridge.app.exceptions import ProfileConfigError, ProfileNotFoundError
+from anibridge.app.utils.cron import CronStr
 from anibridge.app.utils.logging import _get_logger
 
 __all__ = [
     "AnibridgeConfig",
     "AnibridgeProfileConfig",
+    "CronStr",
     "LogLevel",
     "ScanMode",
     "SyncField",
@@ -162,11 +164,13 @@ class AnibridgeProfileConfig(BaseModel):
         default_factory=lambda: [ScanMode.PERIODIC, ScanMode.POLL, ScanMode.WEBHOOK],
         description="List of enabled scan modes (periodic, poll, webhook)",
     )
-    scan_interval: int = Field(
-        default=86400, ge=0, description="Scan interval in seconds"
+    scan_interval: int | CronStr = Field(
+        default=86400,
+        description="Scan interval in seconds or as a cron expression",
     )
-    poll_interval: int = Field(
-        default=60, ge=0, description="Poll scan interval in seconds"
+    poll_interval: int | CronStr = Field(
+        default=60,
+        description="Poll scan interval in seconds or as a cron expression",
     )
     full_scan: bool = Field(
         default=False, description="Perform full library scans, even on unwatched items"

--- a/src/anibridge/app/config/settings.py
+++ b/src/anibridge/app/config/settings.py
@@ -30,7 +30,6 @@ from anibridge.app.utils.logging import _get_logger
 __all__ = [
     "AnibridgeConfig",
     "AnibridgeProfileConfig",
-    "CronStr",
     "LogLevel",
     "ScanMode",
     "SyncField",

--- a/src/anibridge/app/core/bridge.py
+++ b/src/anibridge/app/core/bridge.py
@@ -25,6 +25,7 @@ from anibridge.app.core.sync.stats import SyncProgress, SyncStats
 from anibridge.app.exceptions import MediaTypeError
 from anibridge.app.models.db.housekeeping import Housekeeping
 from anibridge.app.models.db.sync_history import SyncOutcome
+from anibridge.app.utils.cron import get_next_interval_seconds
 from anibridge.app.utils.terminal import ARROW
 
 __all__ = ["BridgeClient"]
@@ -423,7 +424,9 @@ class BridgeClient:
             (
                 self.last_synced
                 or datetime.now(UTC)
-                - timedelta(seconds=self.profile_config.poll_interval)
+                - timedelta(
+                    seconds=get_next_interval_seconds(self.profile_config.poll_interval)
+                )
             )
             - timedelta(seconds=15)  # small buffer
             if poll

--- a/src/anibridge/app/core/sched/client.py
+++ b/src/anibridge/app/core/sched/client.py
@@ -15,6 +15,7 @@ from anibridge.app.core.bridge import BridgeClient
 from anibridge.app.core.sched.coord import GlobalSyncCoordinator
 from anibridge.app.core.sched.profile import ProfileScheduler
 from anibridge.app.exceptions import ProfileNotFoundError
+from anibridge.app.utils.cron import format_interval, is_enabled_interval
 
 __all__ = ["SchedulerClient"]
 
@@ -125,11 +126,11 @@ class SchedulerClient:
             profile_config = self.global_config.get_profile(profile_name)
 
             log.info(
-                "[%s] Starting scheduler: poll_interval=%ss, scan_interval=%ss, "
+                "[%s] Starting scheduler: poll_interval=%s, scan_interval=%s, "
                 "modes=%s, full_scan=%s, destructive=%s",
                 profile_name,
-                profile_config.poll_interval,
-                profile_config.scan_interval,
+                format_interval(profile_config.poll_interval),
+                format_interval(profile_config.scan_interval),
                 profile_config.scan_modes,
                 "enabled" if profile_config.full_scan else "disabled",
                 "enabled" if profile_config.destructive_sync else "disabled",
@@ -153,7 +154,7 @@ class SchedulerClient:
                 next_sync_time = "in progress"
                 if (
                     ScanMode.PERIODIC in profile_config.scan_modes
-                    and profile_config.scan_interval > 0
+                    and is_enabled_interval(profile_config.scan_interval)
                 ):
                     next_sync = datetime.now(UTC).astimezone()
                     next_sync_time = "at {}".format(

--- a/src/anibridge/app/core/sched/client.py
+++ b/src/anibridge/app/core/sched/client.py
@@ -16,6 +16,7 @@ from anibridge.app.core.sched.coord import GlobalSyncCoordinator
 from anibridge.app.core.sched.profile import ProfileScheduler
 from anibridge.app.exceptions import ProfileNotFoundError
 from anibridge.app.utils.cron import format_interval, is_enabled_interval
+from anibridge.app.utils.human import human_duration
 
 __all__ = ["SchedulerClient"]
 
@@ -453,12 +454,12 @@ class SchedulerClient:
                 now = datetime.now(UTC)
                 next_sync_time = self._get_next_1am_utc(now)
 
-                sleep_duration = (next_sync_time - now).total_seconds()
+                sleep_duration = int((next_sync_time - now).total_seconds())
 
                 log.info(
-                    "Next database sync scheduled for: %s (in %.1f hours)",
+                    "Next database sync scheduled for: %s (in %s)",
                     next_sync_time.astimezone(),
-                    sleep_duration / 3600,
+                    human_duration(sleep_duration),
                 )
 
                 try:

--- a/src/anibridge/app/core/sched/profile.py
+++ b/src/anibridge/app/core/sched/profile.py
@@ -16,6 +16,7 @@ from anibridge.app.utils.cron import (
     get_next_interval_seconds,
     get_next_run_datetime,
 )
+from anibridge.app.utils.human import human_duration
 
 
 @dataclass(slots=True)
@@ -324,11 +325,11 @@ class ProfileScheduler:
                 wait_time = get_next_interval_seconds(interval, now)
                 if is_cron:
                     log.info(
-                        "[%s] Next %s sync scheduled for %s (in %s seconds)",
+                        "[%s] Next %s sync scheduled for %s (in %s)",
                         self.profile_name,
                         name,
                         get_next_run_datetime(interval),
-                        wait_time,
+                        human_duration(wait_time),
                     )
                     with contextlib.suppress(asyncio.TimeoutError):
                         await asyncio.wait_for(self.stop_event.wait(), wait_time)
@@ -343,11 +344,11 @@ class ProfileScheduler:
                             break
                     await self.sync(poll=poll, source=f"loop:{name}")
                     log.info(
-                        "[%s] Next %s sync scheduled for %s (in %s seconds)",
+                        "[%s] Next %s sync scheduled for %s (in %s)",
                         self.profile_name,
                         name,
                         get_next_run_datetime(interval),
-                        wait_time,
+                        human_duration(wait_time),
                     )
                 first = False
             except asyncio.CancelledError:

--- a/src/anibridge/app/core/sched/profile.py
+++ b/src/anibridge/app/core/sched/profile.py
@@ -4,12 +4,14 @@ import asyncio
 import contextlib
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 from anibridge.app import log
 from anibridge.app.config.settings import ScanMode
 from anibridge.app.core.bridge import BridgeClient
 from anibridge.app.exceptions import SchedulerUnavailableError
+from anibridge.app.utils.cron import CronStr, get_next_interval_seconds
 
 
 @dataclass(slots=True)
@@ -29,8 +31,8 @@ class ProfileScheduler:
         self,
         profile_name: str,
         bridge_client: BridgeClient,
-        poll_interval: int,
-        scan_interval: int,
+        poll_interval: int | CronStr,
+        scan_interval: int | CronStr,
         scan_modes: list[ScanMode],
         max_pending_waiters: int = DEFAULT_MAX_PENDING_WAITERS,
         before_sync: Callable[[str], Awaitable[None]] | None = None,
@@ -42,8 +44,10 @@ class ProfileScheduler:
         Args:
             profile_name (str): The name of the profile this scheduler manages.
             bridge_client (BridgeClient): The bridge client used to perform syncs.
-            poll_interval (int): The interval in seconds for poll scans.
-            scan_interval (int): The interval in seconds for periodic scans.
+            poll_interval (int | CronStr): The interval in seconds (int) or as a cron
+                expression (str) for poll scans.
+            scan_interval (int | CronStr): The interval in seconds (int) or as a cron
+                expression (str) for periodic scans.
             scan_modes (list[ScanMode]): The scan modes enabled for this profile.
             max_pending_waiters (int): The maximum number of sync requests to queue.
             before_sync (Callable[[str], Awaitable[None]] | None): Optional callback to
@@ -292,7 +296,7 @@ class ProfileScheduler:
             with contextlib.suppress(asyncio.CancelledError):
                 await current_task
 
-    def _spawn_loop(self, *, name: str, interval: int, poll: bool) -> None:
+    def _spawn_loop(self, *, name: str, interval: int | CronStr, poll: bool) -> None:
         """Spawn a periodic loop task to trigger syncs at the given interval."""
         task = asyncio.create_task(
             self._run_loop(name=name, interval=interval, poll=poll)
@@ -300,13 +304,20 @@ class ProfileScheduler:
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
 
-    async def _run_loop(self, *, name: str, interval: int, poll: bool) -> None:
-        """Run a periodic loop to trigger syncs at the given interval."""
+    async def _run_loop(
+        self, *, name: str, interval: int | CronStr, poll: bool
+    ) -> None:
+        """Run a periodic loop to trigger syncs at the given interval.
+
+        For integer intervals, calculates wait time as the interval in seconds.
+        For cron expressions, calculates the next trigger time dynamically.
+        """
         while self._running and not self.stop_event.is_set():
             try:
                 await self.sync(poll=poll, source=f"loop:{name}")
+                wait_time = get_next_interval_seconds(interval, datetime.now())
                 with contextlib.suppress(asyncio.TimeoutError):
-                    await asyncio.wait_for(self.stop_event.wait(), interval)
+                    await asyncio.wait_for(self.stop_event.wait(), wait_time)
             except asyncio.CancelledError:
                 break
             except Exception:

--- a/src/anibridge/app/core/sched/profile.py
+++ b/src/anibridge/app/core/sched/profile.py
@@ -11,7 +11,11 @@ from anibridge.app import log
 from anibridge.app.config.settings import ScanMode
 from anibridge.app.core.bridge import BridgeClient
 from anibridge.app.exceptions import SchedulerUnavailableError
-from anibridge.app.utils.cron import CronStr, get_next_interval_seconds
+from anibridge.app.utils.cron import (
+    CronStr,
+    get_next_interval_seconds,
+    get_next_run_datetime,
+)
 
 
 @dataclass(slots=True)
@@ -309,15 +313,43 @@ class ProfileScheduler:
     ) -> None:
         """Run a periodic loop to trigger syncs at the given interval.
 
-        For integer intervals, calculates wait time as the interval in seconds.
-        For cron expressions, calculates the next trigger time dynamically.
+        For integer intervals, syncs immediately on start, then waits.
+        For cron expressions, waits for the first scheduled time before syncing.
         """
+        is_cron = isinstance(interval, str)
+        first = True
         while self._running and not self.stop_event.is_set():
             try:
-                await self.sync(poll=poll, source=f"loop:{name}")
-                wait_time = get_next_interval_seconds(interval, datetime.now())
-                with contextlib.suppress(asyncio.TimeoutError):
-                    await asyncio.wait_for(self.stop_event.wait(), wait_time)
+                now = datetime.now()
+                wait_time = get_next_interval_seconds(interval, now)
+                if is_cron:
+                    log.info(
+                        "[%s] Next %s sync scheduled for %s (in %s seconds)",
+                        self.profile_name,
+                        name,
+                        get_next_run_datetime(interval),
+                        wait_time,
+                    )
+                    with contextlib.suppress(asyncio.TimeoutError):
+                        await asyncio.wait_for(self.stop_event.wait(), wait_time)
+                    if not self._running or self.stop_event.is_set():
+                        break
+                    await self.sync(poll=poll, source=f"loop:{name}")
+                else:
+                    if not first:
+                        with contextlib.suppress(asyncio.TimeoutError):
+                            await asyncio.wait_for(self.stop_event.wait(), wait_time)
+                        if not self._running or self.stop_event.is_set():
+                            break
+                    await self.sync(poll=poll, source=f"loop:{name}")
+                    log.info(
+                        "[%s] Next %s sync scheduled for %s (in %s seconds)",
+                        self.profile_name,
+                        name,
+                        get_next_run_datetime(interval),
+                        wait_time,
+                    )
+                first = False
             except asyncio.CancelledError:
                 break
             except Exception:

--- a/src/anibridge/app/utils/cron.py
+++ b/src/anibridge/app/utils/cron.py
@@ -1,6 +1,6 @@
 """Utilities for handling cron expressions and intervals."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Annotated
 
 from croniter import croniter
@@ -10,6 +10,7 @@ __all__ = [
     "CronStr",
     "format_interval",
     "get_next_interval_seconds",
+    "get_next_run_datetime",
     "is_enabled_interval",
 ]
 
@@ -22,6 +23,28 @@ def _validate_cron(value: str) -> str:
 
 
 type CronStr = Annotated[str, AfterValidator(_validate_cron)]
+
+
+def get_next_run_datetime(interval: int | str, now: datetime | None = None) -> datetime:
+    """Get the datetime of the next interval trigger.
+
+    Args:
+        interval: Either an integer (seconds) or a cron expression string.
+        now: Optional datetime to compute from (defaults to now).
+
+    Returns:
+        datetime: The datetime of the next trigger.
+    """
+    base = now or datetime.now()
+    if isinstance(interval, int):
+        if interval <= 0:
+            raise ValueError("Integer interval must be greater than 0")
+        return base + timedelta(seconds=interval)
+    if isinstance(interval, str):
+        if not croniter.is_valid(interval):
+            raise ValueError(f"Invalid cron expression: {interval}")
+        return croniter(interval, base).get_next(datetime)
+    raise ValueError(f"Invalid interval type: {type(interval)}")
 
 
 def get_next_interval_seconds(interval: int | str, now: datetime | None = None) -> int:
@@ -37,18 +60,12 @@ def get_next_interval_seconds(interval: int | str, now: datetime | None = None) 
     Raises:
         ValueError: If interval is invalid.
     """
-    if isinstance(interval, int):
-        if interval <= 0:
-            raise ValueError("Integer interval must be greater than 0")
-        return interval
-    if isinstance(interval, str):
-        if not croniter.is_valid(interval):
-            raise ValueError(f"Invalid cron expression: {interval}")
-        cron = croniter(interval, now or datetime.now())
-        next_run = cron.get_next(datetime)
-        delta = next_run - (now or datetime.now())
-        return max(1, int(delta.total_seconds()))
-    raise ValueError(f"Invalid interval type: {type(interval)}")
+    next_run = get_next_run_datetime(interval, now)
+    now = now or datetime.now()
+    wait_time = (next_run - now).total_seconds()
+    if wait_time < 0:
+        raise ValueError("Next run time is in the past")
+    return int(wait_time)
 
 
 def format_interval(interval: int | str) -> str:

--- a/src/anibridge/app/utils/cron.py
+++ b/src/anibridge/app/utils/cron.py
@@ -1,0 +1,19 @@
+"""Utilities for handling cron expressions and intervals."""
+
+from typing import Annotated
+
+from croniter import croniter
+from pydantic import AfterValidator
+
+__all__ = ["CronStr"]
+
+
+def _validate_cron(value: str) -> str:
+    """Validate a cron expression."""
+    if not croniter.is_valid(value):
+        raise ValueError(f"Invalid cron expression: {value}")
+    return value
+
+
+type CronStr = Annotated[str, AfterValidator(_validate_cron)]
+

--- a/src/anibridge/app/utils/cron.py
+++ b/src/anibridge/app/utils/cron.py
@@ -1,11 +1,17 @@
 """Utilities for handling cron expressions and intervals."""
 
+from datetime import datetime
 from typing import Annotated
 
 from croniter import croniter
 from pydantic import AfterValidator
 
-__all__ = ["CronStr"]
+__all__ = [
+    "CronStr",
+    "format_interval",
+    "get_next_interval_seconds",
+    "is_enabled_interval",
+]
 
 
 def _validate_cron(value: str) -> str:
@@ -17,3 +23,61 @@ def _validate_cron(value: str) -> str:
 
 type CronStr = Annotated[str, AfterValidator(_validate_cron)]
 
+
+def get_next_interval_seconds(interval: int | str, now: datetime | None = None) -> int:
+    """Get the seconds to wait until the next interval trigger.
+
+    Args:
+        interval: Either an integer (seconds) or a cron expression string.
+        now: Optional datetime to compute from (defaults to now).
+
+    Returns:
+        int: Seconds to wait until the next interval trigger.
+
+    Raises:
+        ValueError: If interval is invalid.
+    """
+    if isinstance(interval, int):
+        if interval <= 0:
+            raise ValueError("Integer interval must be greater than 0")
+        return interval
+    if isinstance(interval, str):
+        if not croniter.is_valid(interval):
+            raise ValueError(f"Invalid cron expression: {interval}")
+        cron = croniter(interval, now or datetime.now())
+        next_run = cron.get_next(datetime)
+        delta = next_run - (now or datetime.now())
+        return max(1, int(delta.total_seconds()))
+    raise ValueError(f"Invalid interval type: {type(interval)}")
+
+
+def format_interval(interval: int | str) -> str:
+    """Format an interval for display/logging.
+
+    Args:
+        interval: Either an integer (seconds) or a cron expression string.
+
+    Returns:
+        str: Human-readable interval description.
+    """
+    if isinstance(interval, int):
+        return f"{interval}s"
+    if isinstance(interval, str):
+        return f"cron({interval})"
+    return str(interval)
+
+
+def is_enabled_interval(interval: int | str) -> bool:
+    """Check if an interval is enabled (non-zero).
+
+    Args:
+        interval: Either an integer (seconds) or a cron expression string.
+
+    Returns:
+        bool: True if the interval is enabled.
+    """
+    if isinstance(interval, int):
+        return interval > 0
+    if isinstance(interval, str):
+        return croniter.is_valid(interval)
+    return False

--- a/src/anibridge/app/utils/cron.py
+++ b/src/anibridge/app/utils/cron.py
@@ -1,6 +1,6 @@
 """Utilities for handling cron expressions and intervals."""
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Annotated
 
 from croniter import croniter
@@ -35,7 +35,7 @@ def get_next_run_datetime(interval: int | str, now: datetime | None = None) -> d
     Returns:
         datetime: The datetime of the next trigger.
     """
-    base = now or datetime.now()
+    base = now or datetime.now(tz=UTC)
     if isinstance(interval, int):
         if interval <= 0:
             raise ValueError("Integer interval must be greater than 0")

--- a/src/anibridge/app/utils/cron.py
+++ b/src/anibridge/app/utils/cron.py
@@ -22,7 +22,7 @@ def _validate_cron(value: str) -> str:
     return value
 
 
-type CronStr = Annotated[str, AfterValidator(_validate_cron)]
+CronStr = Annotated[str, AfterValidator(_validate_cron)]
 
 
 def get_next_run_datetime(interval: int | str, now: datetime | None = None) -> datetime:

--- a/src/anibridge/app/utils/cron.py
+++ b/src/anibridge/app/utils/cron.py
@@ -60,12 +60,9 @@ def get_next_interval_seconds(interval: int | str, now: datetime | None = None) 
     Raises:
         ValueError: If interval is invalid.
     """
-    next_run = get_next_run_datetime(interval, now)
-    now = now or datetime.now()
-    wait_time = (next_run - now).total_seconds()
-    if wait_time < 0:
-        raise ValueError("Next run time is in the past")
-    return int(wait_time)
+    base = now or datetime.now()
+    next_run = get_next_run_datetime(interval, base)
+    return int((next_run - base).total_seconds())
 
 
 def format_interval(interval: int | str) -> str:

--- a/src/anibridge/app/utils/human.py
+++ b/src/anibridge/app/utils/human.py
@@ -1,0 +1,21 @@
+"""Generate human-readable strings."""
+
+__all__ = ["human_duration"]
+
+
+def human_duration(seconds: int) -> str:
+    """Convert a duration in seconds to a human-readable string."""
+    if seconds < 0:
+        raise ValueError("Duration cannot be negative")
+    parts = []
+    days, seconds = divmod(seconds, 86400)
+    hours, seconds = divmod(seconds, 3600)
+    minutes, seconds = divmod(seconds, 60)
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    parts.append(f"{seconds}s")
+    return " ".join(parts)

--- a/src/anibridge/app/web/routes/api/status.py
+++ b/src/anibridge/app/web/routes/api/status.py
@@ -20,8 +20,8 @@ class ProfileConfigModel(BaseModel):
     list_namespace: str
     library_user: str | None = None
     list_user: str | None = None
-    poll_interval: int | None = None
-    scan_interval: int | None = None
+    poll_interval: int | str | None = None
+    scan_interval: int | str | None = None
     scan_modes: list[str] = []
     full_scan: bool | None = None
     destructive_sync: bool | None = None

--- a/src/anibridge/app/web/routes/api/system.py
+++ b/src/anibridge/app/web/routes/api/system.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 
 from anibridge.app import __git_hash__, __version__
 from anibridge.app.exceptions import AnibridgeError, SchedulerUnavailableError
+from anibridge.app.utils.human import human_duration
 from anibridge.app.web.routes.api.config import require_config_api_access
 from anibridge.app.web.routes.api.status import (
     ProfileConfigModel,
@@ -161,18 +162,7 @@ async def api_about() -> AboutResponse:
     if started_at:
         delta = now - started_at
         uptime_seconds = int(delta.total_seconds())
-        days, rem = divmod(uptime_seconds, 86400)
-        hours, rem = divmod(rem, 3600)
-        minutes, seconds = divmod(rem, 60)
-        parts: list[str] = []
-        if days:
-            parts.append(f"{days}d")
-        if hours:
-            parts.append(f"{hours}h")
-        if minutes:
-            parts.append(f"{minutes}m")
-        parts.append(f"{seconds}s")
-        human_uptime = " ".join(parts)
+        human_uptime = human_duration(uptime_seconds)
 
     info = AboutInfoModel(
         version=__version__,

--- a/tests/core/test_sched.py
+++ b/tests/core/test_sched.py
@@ -229,7 +229,7 @@ async def test_profile_scheduler_run_loop_stops_on_event(
     monkeypatch.setattr(scheduler, "sync", _sync)
 
     scheduler._running = True
-    await scheduler._run_loop(name="periodic", interval=0, poll=False)
+    await scheduler._run_loop(name="periodic", interval=1, poll=False)
 
     assert scheduler.stop_event.is_set()
 
@@ -258,7 +258,7 @@ async def test_profile_scheduler_run_loop_handles_exception(
     monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
 
     scheduler._running = True
-    await scheduler._run_loop(name="poll", interval=0, poll=True)
+    await scheduler._run_loop(name="poll", interval=1, poll=True)
 
     assert scheduler.stop_event.is_set()
 

--- a/uv.lock
+++ b/uv.lock
@@ -117,6 +117,7 @@ dependencies = [
     { name = "anibridge-utils" },
     { name = "bcrypt" },
     { name = "colorama" },
+    { name = "croniter" },
     { name = "fastapi", extra = ["standard-no-fastapi-cloud-cli"] },
     { name = "orjson" },
     { name = "pydantic" },
@@ -151,6 +152,7 @@ requires-dist = [
     { name = "anibridge-utils", specifier = ">=0.2.0b2" },
     { name = "bcrypt", specifier = ">=5.0.0" },
     { name = "colorama", specifier = ">=0.4.6" },
+    { name = "croniter", specifier = ">=6.2.2" },
     { name = "fastapi", extras = ["standard-no-fastapi-cloud-cli"], specifier = ">=0.133.1" },
     { name = "orjson", specifier = ">=3.11.7" },
     { name = "pydantic", specifier = ">=2.12.5" },
@@ -475,6 +477,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/96/38086d58a181aac86d503dfa9c47eb20715a79c3e3acbdf786e92e5c09a8/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932", size = 224148, upload-time = "2026-02-09T12:58:58.645Z" },
     { url = "https://files.pythonhosted.org/packages/ce/72/8d10abd3740a0beb98c305e0c3faf454366221c0f37a8bcf8f60020bb65a/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b", size = 222172, upload-time = "2026-02-09T12:59:00.396Z" },
     { url = "https://files.pythonhosted.org/packages/0d/4a/331fe2caf6799d591109bb9c08083080f6de90a823695d412a935622abb2/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0", size = 211242, upload-time = "2026-02-09T12:59:02.032Z" },
+]
+
+[[package]]
+name = "croniter"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

This PR adds support for cron intervals in the `scan_interval` and `poll_interval` settings. Users can either supply an integer (e.g. `100` for 100 seconds) or a cron string (e.g. `0 0 * * *` for at midnight every day).

Note: this PR also gets rid of a legacy v1 capability of `scan_interval: 0`. Previously, this would cause the scheduler to be disabled. This capability is no longer necessary since disabling scans can be configured through `scan_modes`.

**What's new:**

- Cron parser and validator utilities
- Cron support in the scheduler

**Improvements:**

- Centralized a human duration string utility into `anibridge.app.utils.human` and made it more consistent across the codebase

### Checklist

- [x] I have performed a self-review of my own code
- [x] My code passes the test suite (`pytest`)
- [x] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
