### PR TITLE
Sync rules status enum in AST environment

### DIFF
--- a/src/anibridge/app/config/sync_rules.py
+++ b/src/anibridge/app/config/sync_rules.py
@@ -172,8 +172,11 @@ SYNC_RULE_TEMPLATES: Final[dict[SyncRuleTemplateId, SyncRuleTemplate]] = {
             SyncRuleDefinition.model_validate(
                 {
                     "name": "Don't sync dropped or paused status changes",
-                    "if": 'computed.status in ("dropped", "paused")',
-                    "set": '"current" if current.status is None else current.status',
+                    "if": "computed.status in (ListStatus.DROPPED, ListStatus.PAUSED)",
+                    "set": (
+                        "ListStatus.CURRENT if current.status is None "
+                        "else current.status"
+                    ),
                 }
             ),
         ],
@@ -263,10 +266,11 @@ SYNC_RULE_TEMPLATES: Final[dict[SyncRuleTemplateId, SyncRuleTemplate]] = {
                 {
                     "name": "Promote rewatch to repeating",
                     "if": (
-                        "current.status in ('completed', 'repeating') and "
-                        "computed.status == 'current'"
+                        "current.status in (ListStatus.COMPLETED, "
+                        "ListStatus.REPEATING) and "
+                        "computed.status == ListStatus.CURRENT"
                     ),
-                    "set": "'repeating'",
+                    "set": "ListStatus.REPEATING",
                 }
             )
         ],

--- a/src/anibridge/app/core/sync/rules.py
+++ b/src/anibridge/app/core/sync/rules.py
@@ -34,6 +34,10 @@ _SAFE_FUNCTIONS: dict[str, Any] = {
     "timedelta": timedelta,
 }
 
+_SAFE_GLOBALS: dict[str, Any] = {
+    "ListStatus": ListStatus,
+}
+
 _SAFE_METHODS = {
     "astimezone",
     "capitalize",
@@ -62,11 +66,18 @@ _ALIASES = {
     "none": None,
     "null": None,
     "true": True,
-    **{status.value: status.value for status in ListStatus},
 }
 
 _ALLOWED_NAMES = frozenset(
-    {"computed", "current", "ctx", "vars", *_SAFE_FUNCTIONS, *_ALIASES}
+    {
+        "computed",
+        "current",
+        "ctx",
+        "vars",
+        *_SAFE_FUNCTIONS,
+        *_SAFE_GLOBALS,
+        *_ALIASES,
+    }
 )
 _ALLOWED_NODES = (
     ast.Add,
@@ -148,8 +159,6 @@ class _ContextNamespace(Mapping[str, Any]):
 
     def _normalize(self, value: Any) -> Any:
         """Normalize values before exposing them to expressions."""
-        if isinstance(value, ListStatus):
-            return value.value
         if isinstance(value, Mapping):
             return _ContextNamespace(value, missing_value=self._missing_value)
         if isinstance(value, Sequence) and not isinstance(
@@ -424,6 +433,7 @@ class SyncRuleEngine:
         variables: dict[str, Any] = {}
         base_environment: dict[str, Any] = {
             **_SAFE_FUNCTIONS,
+            **_SAFE_GLOBALS,
             **_ALIASES,
             "current": current,
             "computed": computed,
@@ -458,14 +468,7 @@ class SyncRuleEngine:
         )
         if field_name != "status" or value is None or isinstance(value, ListStatus):
             return value
-        if isinstance(value, str):
-            try:
-                return ListStatus(value)
-            except ValueError as exc:
-                raise ValueError(
-                    f"invalid status value produced by sync rule: {value!r}"
-                ) from exc
         raise ValueError(
-            "sync rule for status must return a string or null, got "
+            "sync rule for status must return a ListStatus or null, got "
             f"{type(value).__name__}"
         )

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -153,7 +153,7 @@ def test_get_profile_raises_for_unknown_name(
 
 
 def test_sync_rules_accept_declarative_field_rules() -> None:
-    """Declarative sync rules should validate and preserve runtime aliases."""
+    """Declarative sync rules should validate and preserve runtime expressions."""
     rules = SyncRulesConfig.model_validate(
         {
             "vars": {
@@ -166,9 +166,10 @@ def test_sync_rules_accept_declarative_field_rules() -> None:
                 {
                     "name": "Promote rewatch",
                     "if": (
-                        'current.status == "completed" and computed.status == "current"'
+                        "current.status == ListStatus.COMPLETED and "
+                        "computed.status == ListStatus.CURRENT"
                     ),
-                    "set": "repeating",
+                    "set": "ListStatus.REPEATING",
                 }
             ],
             "review": [
@@ -186,9 +187,10 @@ def test_sync_rules_accept_declarative_field_rules() -> None:
     review_rules = cast(list[dict[str, object]], field_rules["review"])
 
     assert status_rules[0]["if"] == (
-        'current.status == "completed" and computed.status == "current"'
+        "current.status == ListStatus.COMPLETED and "
+        "computed.status == ListStatus.CURRENT"
     )
-    assert status_rules[0]["set"] == "repeating"
+    assert status_rules[0]["set"] == "ListStatus.REPEATING"
     assert "set" in review_rules[0]
     assert review_rules[0]["set"] is None
 
@@ -225,9 +227,11 @@ def test_sync_rules_disable_dropped_and_paused_template_adds_status_guard() -> N
     status_rules = cast(list[dict[str, object]], rules.field_rules()["status"])
 
     assert status_rules[0]["name"] == "Don't sync dropped or paused status changes"
-    assert status_rules[0]["if"] == 'computed.status in ("dropped", "paused")'
+    assert status_rules[0]["if"] == (
+        "computed.status in (ListStatus.DROPPED, ListStatus.PAUSED)"
+    )
     assert status_rules[0]["set"] == (
-        '"current" if current.status is None else current.status'
+        "ListStatus.CURRENT if current.status is None else current.status"
     )
 
 
@@ -243,9 +247,10 @@ def test_sync_rules_promote_rewatch_template_adds_status_promotion_rule() -> Non
 
     assert status_rules[0]["name"] == "Promote rewatch to repeating"
     assert status_rules[0]["if"] == (
-        "current.status in ('completed', 'repeating') and computed.status == 'current'"
+        "current.status in (ListStatus.COMPLETED, ListStatus.REPEATING) and "
+        "computed.status == ListStatus.CURRENT"
     )
-    assert status_rules[0]["set"] == "'repeating'"
+    assert status_rules[0]["set"] == "ListStatus.REPEATING"
 
 
 def test_sync_rules_disable_review_and_rating_template_overrides_defaults() -> None:

--- a/tests/core/sync/test_base.py
+++ b/tests/core/sync/test_base.py
@@ -346,7 +346,7 @@ async def test_sync_media_does_not_hydrate_unused_ctx_media_fields(
             "status": [
                 {
                     "name": "status without ctx",
-                    "if": 'computed.status == "current"',
+                    "if": "computed.status == ListStatus.CURRENT",
                     "set": "computed.status",
                 }
             ]
@@ -1008,7 +1008,7 @@ async def test_sync_media_info_reports_rule_and_status_blocks(
             "progress": [
                 {
                     "name": "Freeze progress if status is planning",
-                    "if": "current.status == 'planning'",
+                    "if": "current.status == ListStatus.PLANNING",
                     "set": "current.progress",
                 }
             ],
@@ -1056,8 +1056,11 @@ async def test_sync_media_info_reports_applied_sync_rules(
             "status": [
                 {
                     "name": "Promote completed movie",
-                    "if": "computed.status == 'current' and computed.progress == 1",
-                    "set": "completed",
+                    "if": (
+                        "computed.status == ListStatus.CURRENT "
+                        "and computed.progress == 1"
+                    ),
+                    "set": "ListStatus.COMPLETED",
                 }
             ]
         },
@@ -1143,10 +1146,11 @@ async def test_sync_media_applies_declarative_rules(
                 {
                     "name": "Promote rewatch to completed",
                     "if": (
-                        'current.status in ("repeating", "completed") '
-                        'and computed.status == "current"'
+                        "current.status in (ListStatus.REPEATING, "
+                        "ListStatus.COMPLETED) and "
+                        "computed.status == ListStatus.CURRENT"
                     ),
-                    "set": "repeating",
+                    "set": "ListStatus.REPEATING",
                 }
             ],
             "review": [
@@ -1203,10 +1207,11 @@ async def test_sync_media_allows_vars_to_reference_missing_computed_fields(
                 {
                     "name": "Promote rewatch",
                     "if": (
-                        'not vars.has_review and current.status == "completed" '
-                        'and computed.status == "current"'
+                        "not vars.has_review and "
+                        "current.status == ListStatus.COMPLETED and "
+                        "computed.status == ListStatus.CURRENT"
                     ),
-                    "set": "repeating",
+                    "set": "ListStatus.REPEATING",
                 }
             ],
         },
@@ -1289,7 +1294,7 @@ async def test_sync_media_exposes_ctx_item_child_and_grandchildren(
                         "and ctx.grandchildren[1].index == 2 "
                         "and ctx.grandchildren[0].season_index == 1"
                     ),
-                    "set": "completed",
+                    "set": "ListStatus.COMPLETED",
                 }
             ]
         },

--- a/tests/core/sync/test_history.py
+++ b/tests/core/sync/test_history.py
@@ -62,9 +62,22 @@ def history_manager(history_db_factory) -> SyncHistoryManager:
     )
 
 
+class FakeItem:
+    def __init__(self, key: str):
+        self.key = key
+        self.media_kind = MediaKind.MOVIE
+        self._section = SimpleNamespace(key="section-1")
+
+    def section(self):
+        return self._section
+
+    def media(self):
+        return self
+
+
 def _item(key: str = "lib1") -> Any:
-    section = SimpleNamespace(key="section-1")
-    return SimpleNamespace(key=key, media_kind=MediaKind.MOVIE, section=lambda: section)
+
+    return FakeItem(key)
 
 
 def test_stringify_info_value_and_normalize_info(

--- a/tests/core/sync/test_rules.py
+++ b/tests/core/sync/test_rules.py
@@ -23,10 +23,10 @@ def test_context_namespace_normalizes_values_and_missing_access() -> None:
         missing_value=None,
     )
 
-    assert namespace["status"] == "current"
-    assert namespace.nested.status == "planning"
-    assert namespace["items"][0] == "completed"
-    assert namespace["items"][1].status == "dropped"
+    assert namespace["status"] == ListStatus.CURRENT
+    assert namespace.nested.status == ListStatus.PLANNING
+    assert namespace["items"][0] == ListStatus.COMPLETED
+    assert namespace["items"][1].status == ListStatus.DROPPED
     assert list(iter(namespace)) == ["status", "nested", "items"]
     assert len(namespace) == 3
 
@@ -78,7 +78,7 @@ def test_sync_rule_engine_reports_rule_state_and_invalid_status_outputs() -> Non
         computed_values={"progress": 2},
     ) == SyncRuleDecision(allowed=True, value=2)
 
-    with pytest.raises(ValueError, match="invalid status value"):
+    with pytest.raises(ValueError, match="must return a ListStatus or null"):
         engine.evaluate_field(
             field_name="status",
             current_values={"status": ListStatus.PLANNING},
@@ -87,15 +87,42 @@ def test_sync_rule_engine_reports_rule_state_and_invalid_status_outputs() -> Non
         )
 
 
-def test_sync_rule_engine_rejects_non_string_status_values() -> None:
-    """Status rules must resolve to strings, null, or ListStatus values."""
+def test_sync_rule_engine_rejects_non_enum_status_values() -> None:
+    """Status rules must resolve to ListStatus values or null."""
     engine = SyncRuleEngine(
         field_rules={"status": [{"set": 123}]},
     )
 
-    with pytest.raises(ValueError, match="must return a string or null"):
+    with pytest.raises(ValueError, match="must return a ListStatus or null"):
         engine.evaluate_field(
             field_name="status",
             current_values={"status": None},
             computed_values={"status": None},
         )
+
+
+def test_sync_rule_engine_supports_liststatus_class_in_status_rules() -> None:
+    """Status rules should evaluate ListStatus enum members directly."""
+    engine = SyncRuleEngine(
+        field_rules={
+            "status": [
+                {
+                    "name": "prevent regression",
+                    "if": (
+                        "current.status == ListStatus.COMPLETED and "
+                        "computed.status == ListStatus.CURRENT"
+                    ),
+                    "set": "ListStatus.COMPLETED",
+                }
+            ]
+        }
+    )
+
+    result = engine.evaluate_field(
+        field_name="status",
+        current_values={"status": ListStatus.COMPLETED},
+        computed_values={"status": ListStatus.CURRENT},
+    )
+
+    assert result.value == ListStatus.COMPLETED
+    assert result.reason == "prevent regression"


### PR DESCRIPTION
### Description

This PR adds the `ListStatus` enum to the `sync_rules` AST execution environment, enabling proper ordinal comparisons between list statuses in sync rule expressions.

This fixes a bug in #234 where the `prevent_regressions` sync rule was silently broken for status regressions due to attempting ordinal comparisons of `str` and `StrEnum` types (which wasn't supported).

**What's new:**

- `ListStatus` enum availability in the sync rules execution environment

**Fixes:**

- Broken `prevent_regressions` sync rule as a result of incorrect list status comparisons

### Issues Fixed or Closed by this PR

- Closes #234 

### Checklist

- [x] I have performed a self-review of my own code
- [x] My code passes the test suite (`pytest`)
- [x] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
