### PR TITLE
Live config reload

### DIFF
--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -153,13 +153,15 @@
 
         saving = true;
         try {
-            await apiJson<ConfigUpdateResponse>("/api/config", {
+            const response = await apiJson<ConfigUpdateResponse>("/api/config", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(payload),
             });
             toast(
-                "Configuration saved. Restart AniBridge to apply changes.",
+                response.requires_restart
+                    ? "Configuration saved. A restart is required to apply all changes."
+                    : "Configuration saved and applied.",
                 "success",
             );
             await loadConfig();

--- a/src/anibridge/app/core/sched/client.py
+++ b/src/anibridge/app/core/sched/client.py
@@ -573,6 +573,28 @@ class SchedulerClient:
             _reinitialize, timeout_=_MAINTENANCE_TIMEOUT
         )
 
+    async def remove_profile(self, profile_name: str) -> None:
+        """Stop and remove a single profile bridge and scheduler."""
+
+        async def _remove() -> None:
+            log.info("[%s] Removing profile from runtime scheduler", profile_name)
+
+            existing_scheduler = self.profile_schedulers.pop(profile_name, None)
+            if existing_scheduler is not None:
+                await existing_scheduler.stop(set_stop_event=False)
+
+            existing_bridge = self.bridge_clients.pop(profile_name, None)
+            if existing_bridge is not None:
+                await existing_bridge.close()
+
+            self.failed_profile_errors.pop(profile_name, None)
+            self.get_profiles_for_library_provider.cache_clear()
+            log.success("[%s] Profile removed from runtime scheduler", profile_name)
+
+        await self._sync_coordinator.run_maintenance(
+            _remove, timeout_=_MAINTENANCE_TIMEOUT
+        )
+
     @lru_cache(maxsize=128)
     def get_profiles_for_library_provider(self, namespace: str) -> Sequence[str]:
         """Find all profile names and their configs by provider account id.

--- a/src/anibridge/app/web/routes/api/config.py
+++ b/src/anibridge/app/web/routes/api/config.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field, ValidationError
 
 from anibridge.app.config.settings import AnibridgeConfig, get_config
+from anibridge.app.exceptions import SchedulerUnavailableError
 from anibridge.app.web.services.configuration_service import get_configuration_service
 
 __all__ = ["router"]
@@ -94,7 +95,11 @@ async def update_configuration(
         ConfigUpdateResponse: The result of the update operation.
     """
     try:
-        config, mtime = await get_configuration_service().save_document_text(
+        (
+            config,
+            requires_restart,
+            mtime,
+        ) = await get_configuration_service().save_document_text(
             request.content,
             expected_mtime=request.expected_mtime,
         )
@@ -108,6 +113,11 @@ async def update_configuration(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=exc.errors(),
         ) from exc
+    except SchedulerUnavailableError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -117,7 +127,7 @@ async def update_configuration(
     return ConfigUpdateResponse(
         ok=True,
         profiles=sorted(config.profiles.keys()),
-        requires_restart=True,
+        requires_restart=requires_restart,
         mtime=mtime,
     )
 

--- a/src/anibridge/app/web/services/configuration_service.py
+++ b/src/anibridge/app/web/services/configuration_service.py
@@ -2,16 +2,51 @@
 
 import asyncio
 from collections.abc import Mapping
+from operator import attrgetter
 from pathlib import Path
 from typing import Any
 
 import yaml
 from anibridge.utils.cache import cache
+from pydantic import BaseModel, SecretStr
 
 from anibridge.app import log
-from anibridge.app.config.settings import AnibridgeConfig, find_yaml_config_file
+from anibridge.app.config.settings import (
+    AnibridgeConfig,
+    find_yaml_config_file,
+    get_config,
+)
+from anibridge.app.exceptions import SchedulerUnavailableError
+from anibridge.app.web.state import get_app_state
 
 __all__ = ["ConfigurationService", "get_configuration_service"]
+
+_RESTART_REQUIRED_FIELDS: tuple[str, ...] = (
+    "log_level",
+    "provider_classes",
+    "threads",
+    "web.enabled",
+    "web.host",
+    "web.port",
+    "web.basic_auth",
+)
+
+
+def _normalize_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return {
+            field_name: _normalize_value(getattr(value, field_name))
+            for field_name in value.__class__.model_fields
+        }
+    if isinstance(value, SecretStr):
+        return value.get_secret_value()
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(key): _normalize_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_normalize_value(item) for item in value]
+    return value
 
 
 class ConfigurationService:
@@ -26,12 +61,6 @@ class ConfigurationService:
     def config_path(self) -> Path:
         """Return the resolved configuration path."""
         return self._config_path
-
-    def _load_raw_text(self) -> str:
-        """Return the raw YAML content of the configuration file."""
-        if not self._config_path.exists():
-            return ""
-        return self._config_path.read_text(encoding="utf-8")
 
     def _get_mtime_ms(self) -> int | None:
         """Return the modification time of the configuration file in milliseconds."""
@@ -62,17 +91,89 @@ class ConfigurationService:
     def load_document_text(self) -> dict[str, Any]:
         """Return the raw YAML content alongside file metadata."""
         file_exists = self._config_path.exists()
-        content = self._load_raw_text()
         return {
             "config_path": str(self._config_path),
             "file_exists": file_exists,
-            "content": content,
+            "content": ""
+            if not file_exists
+            else self._config_path.read_text(encoding="utf-8"),
             "mtime": self._get_mtime_ms(),
         }
 
+    async def _apply_runtime_config(self, next_config: AnibridgeConfig) -> bool:
+        runtime_config = get_config()
+        scheduler = get_app_state().scheduler
+
+        requires_restart = any(
+            _normalize_value(attrgetter(field_path)(runtime_config))
+            != _normalize_value(attrgetter(field_path)(next_config))
+            for field_path in _RESTART_REQUIRED_FIELDS
+        )
+        current_profiles = {
+            profile_name: _normalize_value(profile)
+            for profile_name, profile in runtime_config.profiles.items()
+        }
+        next_profiles = {
+            profile_name: _normalize_value(profile)
+            for profile_name, profile in next_config.profiles.items()
+        }
+
+        removed_profiles = sorted(set(current_profiles) - set(next_profiles))
+        changed_profiles = sorted(
+            profile_name
+            for profile_name, profile_snapshot in next_profiles.items()
+            if current_profiles.get(profile_name) != profile_snapshot
+        )
+
+        mappings_url_changed = runtime_config.mappings_url != next_config.mappings_url
+        global_defaults_changed = _normalize_value(
+            runtime_config.global_config
+        ) != _normalize_value(next_config.global_config)
+
+        if global_defaults_changed:
+            runtime_config.global_config = next_config.global_config.model_copy(
+                deep=True
+            )
+
+        runtime_config.mappings_url = next_config.mappings_url
+        runtime_config.web.allow_config_without_auth = (
+            next_config.web.allow_config_without_auth
+        )
+
+        for profile_name in removed_profiles:
+            runtime_config.profiles.pop(profile_name, None)
+
+        for profile_name in changed_profiles:
+            profile = next_config.get_profile(profile_name).model_copy(deep=True)
+            profile._parent = runtime_config
+            runtime_config.profiles[profile_name] = profile
+
+        if scheduler is None:
+            return requires_restart
+
+        for profile_name in removed_profiles:
+            await scheduler.remove_profile(profile_name)
+
+        for profile_name in changed_profiles:
+            await scheduler.reinitialize_profile(profile_name)
+
+        if mappings_url_changed:
+            scheduler.shared_animap_client.upstream_url = next_config.mappings_url
+            scheduler.shared_animap_client.mappings_client.upstream_url = (
+                next_config.mappings_url
+            )
+            try:
+                await scheduler.trigger_database_sync(source="api:config:mappings_url")
+            except TimeoutError as exc:
+                raise SchedulerUnavailableError(
+                    "Timed out while refreshing mappings after config update"
+                ) from exc
+
+        return requires_restart
+
     async def save_document_text(
         self, content: str, *, expected_mtime: int | None = None
-    ) -> tuple[AnibridgeConfig, int | None]:
+    ) -> tuple[AnibridgeConfig, bool, int | None]:
         """Persist YAML text after validation and return the updated config."""
         async with self._lock:
             if expected_mtime is not None:
@@ -93,7 +194,8 @@ class ConfigurationService:
                 f"{self._config_path}",
             )
 
-            return config, self._get_mtime_ms()
+            requires_restart = await self._apply_runtime_config(config)
+            return config, requires_restart, self._get_mtime_ms()
 
 
 @cache

--- a/tests/web/routes/api/test_config.py
+++ b/tests/web/routes/api/test_config.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi import HTTPException
 from pydantic import BaseModel, ValidationError
 
+from anibridge.app.exceptions import SchedulerUnavailableError
 from anibridge.app.web.routes.api import config as config_api_module
 
 
@@ -145,6 +146,7 @@ async def test_update_configuration_success_and_error_translation(
             assert expected_mtime == 123
             return (
                 type("Cfg", (), {"profiles": {"b": object(), "a": object()}})(),
+                False,
                 456,
             )
 
@@ -153,12 +155,14 @@ async def test_update_configuration_success_and_error_translation(
     )
     response = await config_api_module.update_configuration(request)
     assert response.profiles == ["a", "b"]
+    assert response.requires_restart is False
     assert response.mtime == 456
 
     for exc, status_code in [
         (FileExistsError("stale"), 409),
         (ValueError("bad"), 400),
         (_validation_error(), 422),
+        (SchedulerUnavailableError("busy"), 503),
     ]:
 
         class _ErrorService:

--- a/tests/web/services/test_configuration_service.py
+++ b/tests/web/services/test_configuration_service.py
@@ -11,6 +11,55 @@ from anibridge.app.web.services import (
 from anibridge.app.web.services.configuration_service import ConfigurationService
 
 
+def _config_text(
+    *,
+    mappings_url: str | None = "https://example.com/mappings-a.json",
+    threads: int | None = None,
+    profiles: str = (
+        "profiles:\n"
+        "  default:\n"
+        "    library_provider: mocklib\n"
+        "    list_provider: mocklist\n"
+    ),
+) -> str:
+    lines: list[str] = []
+    if mappings_url is not None:
+        lines.append(f"mappings_url: {mappings_url}")
+    if threads is not None:
+        lines.append(f"threads: {threads}")
+    lines.append(profiles.rstrip())
+    return "\n".join(lines) + "\n"
+
+
+def _runtime_config(text: str):
+    payload = configuration_service_module.yaml.safe_load(text)
+    return configuration_service_module.AnibridgeConfig.model_validate(payload)
+
+
+class _SchedulerStub:
+    def __init__(self) -> None:
+        self.removed_profiles: list[str] = []
+        self.reinitialized_profiles: list[str] = []
+        self.database_sync_sources: list[str] = []
+        self.shared_animap_client = type(
+            "Animap",
+            (),
+            {
+                "upstream_url": None,
+                "mappings_client": type("Mappings", (), {"upstream_url": None})(),
+            },
+        )()
+
+    async def remove_profile(self, profile_name: str) -> None:
+        self.removed_profiles.append(profile_name)
+
+    async def reinitialize_profile(self, profile_name: str) -> None:
+        self.reinitialized_profiles.append(profile_name)
+
+    async def trigger_database_sync(self, source: str = "manual:database") -> None:
+        self.database_sync_sources.append(source)
+
+
 def test_load_document_text_reports_missing_file(tmp_path: Path):
     """Missing configuration files return empty content with metadata."""
     config_path = tmp_path / "config.yaml"
@@ -24,19 +73,27 @@ def test_load_document_text_reports_missing_file(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_save_document_text_validates_and_persists(tmp_path: Path):
+async def test_save_document_text_validates_and_persists(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
     """Saving text writes to disk and enforces optimistic locking."""
     config_path = tmp_path / "config.yaml"
     service = ConfigurationService(config_path=config_path)
-    text = (
-        "profiles:\n"
-        "  default:\n"
-        "    library_provider: mocklib\n"
-        "    list_provider: mocklist\n"
+    text = _config_text()
+    runtime_config = _runtime_config(text)
+
+    monkeypatch.setattr(
+        configuration_service_module, "get_config", lambda: runtime_config
+    )
+    monkeypatch.setattr(
+        configuration_service_module,
+        "get_app_state",
+        lambda: type("State", (), {"scheduler": None})(),
     )
 
-    config, mtime = await service.save_document_text(text)
+    config, requires_restart, mtime = await service.save_document_text(text)
     assert config.profiles["default"].library_provider == "mocklib"
+    assert requires_restart is False
     assert mtime is not None
 
     # Matching mtime succeeds
@@ -51,13 +108,187 @@ async def test_save_document_text_validates_and_persists(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_save_document_text_rejects_invalid_yaml(tmp_path: Path):
+async def test_save_document_text_rejects_invalid_yaml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
     """Invalid YAML or payloads that are not mappings raise ValueError."""
     config_path = tmp_path / "config.yaml"
     service = ConfigurationService(config_path=config_path)
 
+    monkeypatch.setattr(
+        configuration_service_module,
+        "get_config",
+        lambda: configuration_service_module.AnibridgeConfig.model_validate({}),
+    )
+    monkeypatch.setattr(
+        configuration_service_module,
+        "get_app_state",
+        lambda: type("State", (), {"scheduler": None})(),
+    )
+
     with pytest.raises(ValueError):
         await service.save_document_text("- not a mapping")
+
+
+@pytest.mark.asyncio
+async def test_save_document_text_applies_live_profile_and_mapping_updates(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Live-safe profile and mappings changes should update runtime state."""
+    config_path = tmp_path / "config.yaml"
+    service = ConfigurationService(config_path=config_path)
+
+    initial_text = _config_text(mappings_url="https://example.com/mappings-a.json")
+    updated_text = _config_text(
+        mappings_url="https://example.com/mappings-b.json",
+        profiles=(
+            "profiles:\n"
+            "  default:\n"
+            "    library_provider: mocklib\n"
+            "    list_provider: mocklist\n"
+            "    scan_interval: 120\n"
+        ),
+    )
+    runtime_config = _runtime_config(initial_text)
+    scheduler = _SchedulerStub()
+
+    monkeypatch.setattr(
+        configuration_service_module, "get_config", lambda: runtime_config
+    )
+    monkeypatch.setattr(
+        configuration_service_module,
+        "get_app_state",
+        lambda: type("State", (), {"scheduler": scheduler})(),
+    )
+
+    _, requires_restart, _ = await service.save_document_text(updated_text)
+
+    assert requires_restart is False
+    assert runtime_config.mappings_url == "https://example.com/mappings-b.json"
+    assert runtime_config.profiles["default"].scan_interval == 120
+    assert scheduler.reinitialized_profiles == ["default"]
+    assert scheduler.database_sync_sources == ["api:config:mappings_url"]
+    assert (
+        scheduler.shared_animap_client.mappings_client.upstream_url
+        == "https://example.com/mappings-b.json"
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_document_text_marks_restart_only_fields_pending(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Restart-only fields should be persisted without mutating the runtime config."""
+    config_path = tmp_path / "config.yaml"
+    service = ConfigurationService(config_path=config_path)
+
+    initial_text = _config_text(threads=2)
+    updated_text = _config_text(threads=8)
+    runtime_config = _runtime_config(initial_text)
+    scheduler = _SchedulerStub()
+
+    monkeypatch.setattr(
+        configuration_service_module, "get_config", lambda: runtime_config
+    )
+    monkeypatch.setattr(
+        configuration_service_module,
+        "get_app_state",
+        lambda: type("State", (), {"scheduler": scheduler})(),
+    )
+
+    _, requires_restart, _ = await service.save_document_text(updated_text)
+
+    assert requires_restart is True
+    assert runtime_config.threads == 2
+    assert scheduler.reinitialized_profiles == []
+    assert scheduler.database_sync_sources == []
+
+
+@pytest.mark.asyncio
+async def test_save_document_text_marks_nested_restart_only_fields_pending(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Nested restart-only fields should also be detected by field path."""
+    config_path = tmp_path / "config.yaml"
+    service = ConfigurationService(config_path=config_path)
+
+    initial_text = _config_text()
+    updated_text = (
+        "mappings_url: https://example.com/mappings-a.json\n"
+        "web:\n"
+        "  host: 0.0.0.0\n"
+        "profiles:\n"
+        "  default:\n"
+        "    library_provider: mocklib\n"
+        "    list_provider: mocklist\n"
+    )
+    runtime_config = _runtime_config(initial_text)
+    scheduler = _SchedulerStub()
+
+    monkeypatch.setattr(
+        configuration_service_module, "get_config", lambda: runtime_config
+    )
+    monkeypatch.setattr(
+        configuration_service_module,
+        "get_app_state",
+        lambda: type("State", (), {"scheduler": scheduler})(),
+    )
+
+    _, requires_restart, _ = await service.save_document_text(updated_text)
+
+    assert requires_restart is True
+    assert runtime_config.web.host == ""
+    assert scheduler.reinitialized_profiles == []
+
+
+@pytest.mark.asyncio
+async def test_save_document_text_adds_and_removes_profiles_live(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Added and removed profiles should be reflected immediately at runtime."""
+    config_path = tmp_path / "config.yaml"
+    service = ConfigurationService(config_path=config_path)
+
+    initial_text = _config_text(
+        profiles=(
+            "profiles:\n"
+            "  alpha:\n"
+            "    library_provider: mocklib\n"
+            "    list_provider: mocklist\n"
+            "  beta:\n"
+            "    library_provider: mocklib\n"
+            "    list_provider: mocklist\n"
+        ),
+    )
+    updated_text = _config_text(
+        profiles=(
+            "profiles:\n"
+            "  alpha:\n"
+            "    library_provider: mocklib\n"
+            "    list_provider: mocklist\n"
+            "  gamma:\n"
+            "    library_provider: mocklib\n"
+            "    list_provider: mocklist\n"
+        ),
+    )
+    runtime_config = _runtime_config(initial_text)
+    scheduler = _SchedulerStub()
+
+    monkeypatch.setattr(
+        configuration_service_module, "get_config", lambda: runtime_config
+    )
+    monkeypatch.setattr(
+        configuration_service_module,
+        "get_app_state",
+        lambda: type("State", (), {"scheduler": scheduler})(),
+    )
+
+    _, requires_restart, _ = await service.save_document_text(updated_text)
+
+    assert requires_restart is False
+    assert sorted(runtime_config.profiles) == ["alpha", "gamma"]
+    assert scheduler.removed_profiles == ["beta"]
+    assert scheduler.reinitialized_profiles == ["gamma"]
 
 
 def test_configuration_service_exposes_config_path_and_mtime(tmp_path: Path) -> None:


### PR DESCRIPTION
### Description

This PR implements live config reloading through the API (and web UI). Restarting the server after config changes is no longer required, besides a few special fields.

**What's new:**

- Config reload from the configuration API service 

### Issues Fixed or Closed by this PR

- Closes #246 

### Checklist

- [x] I have performed a self-review of my own code
- [x] My code passes the test suite (`pytest`)
- [x] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
