### PR TITLE
Guided config web UI

### DIFF
--- a/frontend/src/lib/components/config/schema-form-node.svelte
+++ b/frontend/src/lib/components/config/schema-form-node.svelte
@@ -10,11 +10,11 @@
         getArrayItemSchema,
         getObjectProperties,
         getPreferredSchema,
-        getPrimitiveTypes,
         getRequiredKeys,
         humanizeKey,
         makeDefaultValue,
         resolveSchema,
+        schemaMatchesValue,
         type JsonPath,
         type SchemaObject,
     } from "./schema-form";
@@ -30,6 +30,8 @@
         depth?: number;
         showHeader?: boolean;
         addLabel?: string;
+        suppressHeaderlessAddAction?: boolean;
+        suppressHeaderlessUnionSelector?: boolean;
         onChange: (path: JsonPath, value: unknown) => void;
         onDelete?: (path: JsonPath) => void;
     }
@@ -44,22 +46,20 @@
         depth = 0,
         showHeader = true,
         addLabel = undefined,
+        suppressHeaderlessAddAction = false,
+        suppressHeaderlessUnionSelector = false,
         onChange,
         onDelete = undefined,
     }: Props = $props();
 
-    function schemaMatchesValue(option: SchemaObject, candidate: unknown): boolean {
-        if (candidate === null) return option.type === "null";
-        if (Array.isArray(candidate)) return option.type === "array";
-        if (typeof candidate === "boolean") return option.type === "boolean";
-        if (typeof candidate === "number") {
-            return option.type === "number" || option.type === "integer";
-        }
-        if (typeof candidate === "string") return option.type === "string";
-        if (candidate && typeof candidate === "object") {
-            return option.type === "object" || typeof option.properties === "object";
-        }
-        return false;
+    const unionSelectorClass =
+        "flex max-w-full flex-wrap items-center rounded-md border border-slate-700/80 bg-slate-900/80 p-0.5";
+
+    function getUnionIndex(options: SchemaObject[], candidate: unknown): number {
+        return Math.max(
+            options.findIndex((option) => schemaMatchesValue(option, candidate)),
+            options.length > 0 ? 0 : -1,
+        );
     }
 
     function getUnionOptionLabel(option: SchemaObject, index: number): string {
@@ -95,21 +95,7 @@
     const currentUnionValue = $derived(
         value === undefined ? baseSchema.default : value,
     );
-    const currentUnionIndex = $derived(
-        Math.max(
-            anyOfOptions.findIndex((option) =>
-                schemaMatchesValue(option, currentUnionValue),
-            ),
-            anyOfOptions.length > 0 ? 0 : -1,
-        ),
-    );
-    const unionEntries = $derived(
-        anyOfOptions.map((option, index) => ({
-            index,
-            label: getUnionOptionLabel(option, index),
-            schema: option,
-        })),
-    );
+    const currentUnionIndex = $derived(getUnionIndex(anyOfOptions, currentUnionValue));
     const title = $derived(
         (typeof resolvedSchema.title === "string" && resolvedSchema.title) ||
             label ||
@@ -139,7 +125,6 @@
     );
     const itemSchema = $derived(getArrayItemSchema(resolvedSchema, rootSchema));
     const arrayValue = $derived(Array.isArray(value) ? value : []);
-    const primitiveTypes = $derived(getPrimitiveTypes(resolvedSchema, rootSchema));
     const isObject = $derived(
         resolvedSchema.type === "object" ||
             knownKeys.length > 0 ||
@@ -152,19 +137,68 @@
     const isNumeric = $derived(
         resolvedSchema.type === "integer" || resolvedSchema.type === "number",
     );
+    const allowsNull = $derived(
+        isNull || anyOfOptions.some((option) => option.type === "null"),
+    );
+    const pathKey = $derived(String(path.join(".")));
+    const showHeaderlessUnionSelector = $derived(
+        !showHeader && !suppressHeaderlessUnionSelector && anyOfOptions.length > 1,
+    );
+
+    function promptForEntryKey(message: string, currentValue: unknown): string | null {
+        const nextKey = window.prompt(message);
+        const normalized = nextKey?.trim();
+        const currentEntryValue = asRecord(currentValue);
+        return !normalized || currentEntryValue[normalized] !== undefined
+            ? null
+            : normalized;
+    }
+
+    function addObjectEntry(
+        entryPath: JsonPath,
+        currentValue: unknown,
+        entrySchema: SchemaObject,
+        promptMessage: string,
+    ) {
+        const entryAdditionalSchema = getAdditionalPropertiesSchema(
+            entrySchema,
+            rootSchema,
+        );
+        if (!entryAdditionalSchema) return;
+
+        const nextKey = promptForEntryKey(promptMessage, currentValue);
+        if (!nextKey) return;
+
+        onChange(
+            [...entryPath, nextKey],
+            makeDefaultValue(entryAdditionalSchema, rootSchema),
+        );
+    }
 
     function promptAddObjectEntry() {
-        if (!additionalSchema) return;
-
-        const nextKey = window.prompt(`New ${addLabel ?? "entry"} name`);
-        const normalized = nextKey?.trim();
-        if (!normalized || objectValue[normalized] !== undefined) return;
-
-        onChange([...path, normalized], makeDefaultValue(additionalSchema, rootSchema));
+        addObjectEntry(
+            path,
+            objectValue,
+            resolvedSchema,
+            `New ${addLabel ?? "entry"} name`,
+        );
     }
 
     function addArrayItem() {
         onChange(path, [...arrayValue, makeDefaultValue(itemSchema, rootSchema)]);
+    }
+
+    function addArrayItemAt(
+        entryPath: JsonPath,
+        currentValue: unknown,
+        entrySchema: SchemaObject,
+    ) {
+        const currentItems = Array.isArray(currentValue) ? currentValue : [];
+        const nextItemSchema = getArrayItemSchema(entrySchema, rootSchema);
+        onChange(entryPath, [
+            ...currentItems,
+            makeDefaultValue(nextItemSchema, rootSchema),
+        ]);
     }
 
     function removeArrayItem(index: number) {
@@ -174,12 +208,17 @@
         );
     }
 
-    function updateUnionSelection(nextIndex: number) {
-        const entry = unionEntries[nextIndex];
-        if (!entry) return;
+    function selectUnionOption(
+        entryPath: JsonPath,
+        parentSchema: SchemaObject,
+        currentValue: unknown,
+        options: SchemaObject[],
+        nextIndex: number,
+    ) {
+        const option = options[nextIndex];
+        if (!option || schemaMatchesValue(option, currentValue)) return;
 
-        if (schemaMatchesValue(entry.schema, currentUnionValue)) return;
-        onChange(path, getUnionOptionDefault(entry.schema, baseSchema));
+        onChange(entryPath, getUnionOptionDefault(option, parentSchema));
     }
 
     const wrapperClass = $derived(
@@ -187,52 +226,126 @@
             ? "space-y-4"
             : "space-y-4 rounded-md border border-slate-800/70 bg-slate-950/40 p-4",
     );
+
+    const addButtonClass =
+        "inline-flex items-center rounded-md border border-slate-700/60 bg-slate-900/60 p-1 text-[12px] font-semibold text-emerald-200 shadow-sm transition-colors hover:border-emerald-400 hover:text-emerald-100 focus:outline-none disabled:pointer-events-none disabled:opacity-50 disabled:hover:border-slate-700/60 disabled:hover:text-emerald-200";
+    const removeButtonClass =
+        "inline-flex items-center rounded-md border border-slate-700/60 bg-slate-900/60 p-1 text-[12px] font-semibold text-rose-200 transition-colors hover:border-rose-500 focus:outline-none disabled:pointer-events-none disabled:opacity-50 disabled:hover:border-slate-700/60 disabled:hover:text-rose-200";
 </script>
+
+{#snippet renderHeaderDetails(
+    headerTitle: string | undefined,
+    headerDescription: string | null,
+    headerRequired: boolean,
+)}
+    {#if headerDescription}
+        <Tooltip
+            class="z-20 max-w-xs rounded-md border border-slate-800/70 bg-slate-900/95 px-2 py-1.5 text-[11px] leading-relaxed text-slate-100 shadow-xl">
+            {#snippet trigger()}
+                <button
+                    type="button"
+                    class="inline-flex h-5 w-5 items-center justify-center rounded-full text-slate-500 transition-colors hover:text-slate-200 focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:outline-none"
+                    aria-label={`${headerTitle} description`}>
+                    <Info class="h-3.5 w-3.5" />
+                </button>
+            {/snippet}
+            {headerDescription}
+        </Tooltip>
+    {/if}
+    {#if headerRequired}
+        <span
+            class="rounded-full border border-blue-500/40 bg-blue-500/10 px-2 py-0.5 text-[10px] font-medium tracking-wide text-blue-200">
+            Required
+        </span>
+    {/if}
+{/snippet}
+
+{#snippet renderUnionSelector(
+    options: SchemaObject[],
+    activeIndex: number,
+    keyPrefix: string,
+    entryPath: JsonPath,
+    parentSchema: SchemaObject,
+    currentValue: unknown,
+)}
+    <div class={unionSelectorClass}>
+        {#each options as option, index (`${keyPrefix}:${index}`)}
+            <button
+                type="button"
+                class={`rounded-md px-2 py-0.5 text-[10px] font-medium transition ${index === activeIndex ? "bg-blue-600 text-white" : "text-slate-400 hover:text-slate-200"}`}
+                onclick={() =>
+                    selectUnionOption(
+                        entryPath,
+                        parentSchema,
+                        currentValue,
+                        options,
+                        index,
+                    )}>
+                {getUnionOptionLabel(option, index)}
+            </button>
+        {/each}
+    </div>
+{/snippet}
 
 {#if isObject}
     <div class={wrapperClass}>
         {#if showHeader && title}
             <div class="space-y-1">
-                <div class="flex items-center justify-between gap-3">
+                <div
+                    class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                     <div class="flex min-w-0 items-center gap-2">
+                        {#if additionalSchema}
+                            <button
+                                type="button"
+                                class={addButtonClass}
+                                title={`Add ${addLabel ?? "entry"}`}
+                                aria-label={`Add ${addLabel ?? "entry"}`}
+                                onclick={promptAddObjectEntry}>
+                                <CirclePlus class="inline h-4 w-4" />
+                            </button>
+                        {/if}
                         <h3 class="truncate text-sm font-semibold text-slate-100">
                             {title}
                         </h3>
-                        {#if description}
-                            <Tooltip
-                                class="z-20 max-w-xs rounded-md border border-slate-800/70 bg-slate-900/95 px-2 py-1.5 text-[11px] leading-relaxed text-slate-100 shadow-xl">
-                                {#snippet trigger()}
-                                    <button
-                                        type="button"
-                                        class="inline-flex h-5 w-5 items-center justify-center rounded-full text-slate-500 transition-colors hover:text-slate-200 focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:outline-none"
-                                        aria-label={`${title} description`}>
-                                        <Info class="h-3.5 w-3.5" />
-                                    </button>
-                                {/snippet}
-                                {description}
-                            </Tooltip>
-                        {/if}
-                        {#if required}
-                            <span
-                                class="rounded-full border border-blue-500/40 bg-blue-500/10 px-2 py-0.5 text-[10px] font-medium tracking-wide text-blue-200">
-                                Required
-                            </span>
-                        {/if}
+                        {@render renderHeaderDetails(title, description, required)}
                     </div>
-                    {#if unionEntries.length > 1}
-                        <div
-                            class="inline-flex shrink-0 items-center rounded-md border border-slate-700/80 bg-slate-900/80 p-0.5">
-                            {#each unionEntries as entry (`${String(path.join("."))}:${entry.index}`)}
-                                <button
-                                    type="button"
-                                    class={`rounded-md px-2 py-0.5 text-[10px] font-medium transition ${entry.index === currentUnionIndex ? "bg-blue-600 text-white" : "text-slate-400 hover:text-slate-200"}`}
-                                    onclick={() => updateUnionSelection(entry.index)}>
-                                    {entry.label}
-                                </button>
-                            {/each}
-                        </div>
+                    {#if anyOfOptions.length > 1}
+                        {@render renderUnionSelector(
+                            anyOfOptions,
+                            currentUnionIndex,
+                            pathKey,
+                            path,
+                            baseSchema,
+                            currentUnionValue,
+                        )}
                     {/if}
                 </div>
+            </div>
+        {/if}
+
+        {#if showHeaderlessUnionSelector}
+            <div class="flex justify-start">
+                {@render renderUnionSelector(
+                    anyOfOptions,
+                    currentUnionIndex,
+                    pathKey,
+                    path,
+                    baseSchema,
+                    currentUnionValue,
+                )}
+            </div>
+        {/if}
+
+        {#if additionalSchema && (!showHeader || !title) && !suppressHeaderlessAddAction}
+            <div class="flex justify-end">
+                <button
+                    type="button"
+                    class={addButtonClass}
+                    title={`Add ${addLabel ?? "entry"}`}
+                    aria-label={`Add ${addLabel ?? "entry"}`}
+                    onclick={promptAddObjectEntry}>
+                    <CirclePlus class="inline h-4 w-4" />
+                </button>
             </div>
         {/if}
 
@@ -250,167 +363,239 @@
         {/each}
 
         {#each extraKeys as key (key)}
+            {@const extraEntrySchema = additionalSchema ?? {}}
+            {@const extraEntryResolvedSchema = getPreferredSchema(
+                extraEntrySchema,
+                rootSchema,
+                objectValue[key],
+            )}
+            {@const extraEntryCanAdd =
+                getAdditionalPropertiesSchema(extraEntrySchema, rootSchema) !== null}
+            {@const extraEntryIsArray = extraEntryResolvedSchema.type === "array"}
+            {@const extraEntryUnionOptions = getAnyOfOptions(
+                extraEntrySchema,
+                rootSchema,
+            )}
+            {@const extraEntryUnionIndex = getUnionIndex(
+                extraEntryUnionOptions,
+                objectValue[key],
+            )}
             <div
                 class="space-y-3 rounded-md border border-slate-800/70 bg-slate-950/40 p-4">
-                <div class="flex items-center justify-between gap-3">
-                    <div>
-                        <h4 class="text-sm font-semibold text-slate-100">{key}</h4>
-                        <p class="text-xs text-slate-500">Custom entry</p>
+                <div
+                    class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div class="flex min-w-0 items-center gap-2">
+                        {#if extraEntryCanAdd || extraEntryIsArray}
+                            <button
+                                type="button"
+                                class={addButtonClass}
+                                title={extraEntryIsArray ? "Add item" : "Add entry"}
+                                aria-label={extraEntryIsArray
+                                    ? "Add item"
+                                    : "Add entry"}
+                                onclick={() =>
+                                    extraEntryIsArray
+                                        ? addArrayItemAt(
+                                              [...path, key],
+                                              objectValue[key],
+                                              extraEntryResolvedSchema,
+                                          )
+                                        : addObjectEntry(
+                                              [...path, key],
+                                              objectValue[key],
+                                              extraEntrySchema,
+                                              "New entry name",
+                                          )}>
+                                <CirclePlus class="inline h-4 w-4" />
+                            </button>
+                        {/if}
+                        <h4 class="truncate text-sm font-semibold text-slate-100">
+                            {key}
+                        </h4>
                     </div>
-                    {#if onDelete}
-                        <button
-                            type="button"
-                            class="inline-flex items-center gap-1 rounded-md border border-rose-900/70 bg-rose-950/40 px-2.5 py-1 text-[11px] font-medium text-rose-100 hover:bg-rose-900/40"
-                            onclick={() => onDelete?.([...path, key])}>
-                            <Trash2 class="h-3.5 w-3.5" /> Remove
-                        </button>
-                    {/if}
+                    <div
+                        class="flex max-w-full flex-wrap items-center gap-2 sm:justify-end">
+                        {#if extraEntryUnionOptions.length > 1}
+                            {@render renderUnionSelector(
+                                extraEntryUnionOptions,
+                                extraEntryUnionIndex,
+                                `${pathKey}.${key}`,
+                                [...path, key],
+                                extraEntrySchema,
+                                objectValue[key],
+                            )}
+                        {/if}
+                        {#if onDelete}
+                            <button
+                                type="button"
+                                class={removeButtonClass}
+                                title="Remove custom entry"
+                                aria-label="Remove custom entry"
+                                onclick={() => onDelete?.([...path, key])}>
+                                <Trash2 class="inline h-4 w-4" />
+                            </button>
+                        {/if}
+                    </div>
                 </div>
                 <SchemaFormNode
                     {rootSchema}
-                    schema={additionalSchema ?? {}}
+                    schema={extraEntrySchema}
                     value={objectValue[key]}
                     path={[...path, key]}
                     label={key}
                     depth={depth + 1}
                     showHeader={false}
+                    suppressHeaderlessAddAction={extraEntryCanAdd || extraEntryIsArray}
+                    suppressHeaderlessUnionSelector={extraEntryUnionOptions.length > 1}
                     {onChange}
                     {onDelete} />
             </div>
         {/each}
-
-        {#if additionalSchema}
-            <button
-                type="button"
-                class="inline-flex items-center gap-1 rounded-md border border-slate-700 bg-slate-900/70 px-3 py-1.5 text-xs font-medium text-slate-200 hover:bg-slate-800/70"
-                onclick={promptAddObjectEntry}>
-                <CirclePlus class="h-3.5 w-3.5" /> Add {addLabel ?? "entry"}
-            </button>
-        {/if}
     </div>
 {:else if isArray}
     <div class={wrapperClass}>
         {#if showHeader && title}
             <div class="space-y-1">
-                <div class="flex items-center justify-between gap-3">
+                <div
+                    class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                     <div class="flex min-w-0 items-center gap-2">
+                        <button
+                            type="button"
+                            class={addButtonClass}
+                            title="Add item"
+                            aria-label="Add item"
+                            onclick={addArrayItem}>
+                            <CirclePlus class="inline h-4 w-4" />
+                        </button>
                         <h3 class="truncate text-sm font-semibold text-slate-100">
                             {title}
                         </h3>
-                        {#if description}
-                            <Tooltip
-                                class="z-20 max-w-xs rounded-md border border-slate-800/70 bg-slate-900/95 px-2 py-1.5 text-[11px] leading-relaxed text-slate-100 shadow-xl">
-                                {#snippet trigger()}
-                                    <button
-                                        type="button"
-                                        class="inline-flex h-5 w-5 items-center justify-center rounded-full text-slate-500 transition-colors hover:text-slate-200 focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:outline-none"
-                                        aria-label={`${title} description`}>
-                                        <Info class="h-3.5 w-3.5" />
-                                    </button>
-                                {/snippet}
-                                {description}
-                            </Tooltip>
-                        {/if}
-                        {#if required}
-                            <span
-                                class="rounded-full border border-blue-500/40 bg-blue-500/10 px-2 py-0.5 text-[10px] font-medium tracking-wide text-blue-200">
-                                Required
-                            </span>
-                        {/if}
+                        {@render renderHeaderDetails(title, description, required)}
                     </div>
-                    {#if unionEntries.length > 1}
-                        <div
-                            class="inline-flex shrink-0 items-center rounded-md border border-slate-700/80 bg-slate-900/80 p-0.5">
-                            {#each unionEntries as entry (`${String(path.join("."))}:${entry.index}`)}
-                                <button
-                                    type="button"
-                                    class={`rounded-md px-2 py-0.5 text-[10px] font-medium transition ${entry.index === currentUnionIndex ? "bg-blue-600 text-white" : "text-slate-400 hover:text-slate-200"}`}
-                                    onclick={() => updateUnionSelection(entry.index)}>
-                                    {entry.label}
-                                </button>
-                            {/each}
-                        </div>
+                    {#if anyOfOptions.length > 1}
+                        {@render renderUnionSelector(
+                            anyOfOptions,
+                            currentUnionIndex,
+                            pathKey,
+                            path,
+                            baseSchema,
+                            currentUnionValue,
+                        )}
                     {/if}
                 </div>
             </div>
         {/if}
 
-        <div class="flex flex-wrap gap-3">
-            {#each arrayValue as item, index (`${String(path.join("."))}:${index}`)}
-                <div
-                    class="min-w-[18rem] flex-1 space-y-3 rounded-md border border-slate-800/70 bg-slate-950/40 p-4">
-                    <div class="flex items-center justify-between gap-3">
-                        <p class="text-xs font-medium text-slate-300">
-                            Item {index + 1}
-                        </p>
-                        <button
-                            type="button"
-                            class="inline-flex items-center gap-1 rounded-md border border-rose-900/70 bg-rose-950/40 px-2.5 py-1 text-[11px] font-medium text-rose-100 hover:bg-rose-900/40"
-                            onclick={() => removeArrayItem(index)}>
-                            <Trash2 class="h-3.5 w-3.5" /> Remove
-                        </button>
-                    </div>
-                    <SchemaFormNode
-                        {rootSchema}
-                        schema={itemSchema}
-                        value={item}
-                        path={[...path, index]}
-                        depth={depth + 1}
-                        showHeader={false}
-                        {onChange}
-                        {onDelete} />
-                </div>
-            {/each}
-        </div>
+        {#if showHeaderlessUnionSelector}
+            <div class="flex justify-start">
+                {@render renderUnionSelector(
+                    anyOfOptions,
+                    currentUnionIndex,
+                    pathKey,
+                    path,
+                    baseSchema,
+                    currentUnionValue,
+                )}
+            </div>
+        {/if}
 
-        <button
-            type="button"
-            class="inline-flex items-center gap-1 rounded-md border border-slate-700 bg-slate-900/70 px-3 py-1.5 text-xs font-medium text-slate-200 hover:bg-slate-800/70"
-            onclick={addArrayItem}>
-            <CirclePlus class="h-3.5 w-3.5" /> Add item
-        </button>
+        {#if (!showHeader || !title) && !suppressHeaderlessAddAction}
+            <div class="flex justify-end">
+                <button
+                    type="button"
+                    class={addButtonClass}
+                    title="Add item"
+                    aria-label="Add item"
+                    onclick={addArrayItem}>
+                    <CirclePlus class="inline h-4 w-4" />
+                </button>
+            </div>
+        {/if}
+
+        {#if arrayValue.length > 0}
+            <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+                {#each arrayValue as item, index (`${pathKey}:${index}`)}
+                    {@const itemUnionOptions = getAnyOfOptions(itemSchema, rootSchema)}
+                    {@const itemUnionIndex = getUnionIndex(itemUnionOptions, item)}
+                    <div
+                        class="min-w-0 flex-1 space-y-3 rounded-md border border-slate-800/70 bg-slate-950/40 p-4 sm:min-w-[18rem]">
+                        <div
+                            class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                            <div class="flex min-w-0 items-center gap-2">
+                                <p class="text-xs font-medium text-slate-300">
+                                    #{index + 1}
+                                </p>
+                            </div>
+                            <div
+                                class="flex max-w-full flex-wrap items-center gap-2 sm:justify-end">
+                                {#if itemUnionOptions.length > 1}
+                                    {@render renderUnionSelector(
+                                        itemUnionOptions,
+                                        itemUnionIndex,
+                                        `${pathKey}:${index}`,
+                                        [...path, index],
+                                        itemSchema,
+                                        item,
+                                    )}
+                                {/if}
+                                <button
+                                    type="button"
+                                    class={removeButtonClass}
+                                    title="Remove item"
+                                    aria-label="Remove item"
+                                    onclick={() => removeArrayItem(index)}>
+                                    <Trash2 class="inline h-4 w-4" />
+                                </button>
+                            </div>
+                        </div>
+                        <SchemaFormNode
+                            {rootSchema}
+                            schema={itemSchema}
+                            value={item}
+                            path={[...path, index]}
+                            depth={depth + 1}
+                            showHeader={false}
+                            suppressHeaderlessUnionSelector={itemUnionOptions.length >
+                                1}
+                            {onChange}
+                            {onDelete} />
+                    </div>
+                {/each}
+            </div>
+        {/if}
     </div>
 {:else}
     <label class="block space-y-1.5">
-        {#if title}
-            <div class="flex items-center justify-between gap-3">
+        {#if showHeader && title}
+            <div
+                class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div
-                    class="flex min-w-0 items-center gap-2 text-xs font-medium tracking-wide text-slate-200">
+                    class="flex min-w-0 flex-wrap items-center gap-2 text-xs font-medium tracking-wide text-slate-200">
                     <span class="truncate">{title}</span>
-                    {#if description}
-                        <Tooltip
-                            class="z-20 max-w-xs rounded-md border border-slate-800/70 bg-slate-900/95 px-2 py-1.5 text-[11px] leading-relaxed text-slate-100 shadow-xl">
-                            {#snippet trigger()}
-                                <button
-                                    type="button"
-                                    class="inline-flex h-5 w-5 items-center justify-center rounded-full text-slate-500 transition-colors hover:text-slate-200 focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:outline-none"
-                                    aria-label={`${title} description`}>
-                                    <Info class="h-3.5 w-3.5" />
-                                </button>
-                            {/snippet}
-                            {description}
-                        </Tooltip>
-                    {/if}
-                    {#if required}
-                        <span
-                            class="rounded-full border border-blue-500/40 bg-blue-500/10 px-2 py-0.5 text-[10px] font-medium tracking-wide text-blue-200">
-                            Required
-                        </span>
-                    {/if}
+                    {@render renderHeaderDetails(title, description, required)}
                 </div>
-                {#if unionEntries.length > 1}
-                    <div
-                        class="inline-flex shrink-0 items-center rounded-md border border-slate-700/80 bg-slate-900/80 p-0.5">
-                        {#each unionEntries as entry (`${String(path.join("."))}:${entry.index}`)}
-                            <button
-                                type="button"
-                                class={`rounded-md px-2 py-0.5 text-[10px] font-medium transition ${entry.index === currentUnionIndex ? "bg-blue-600 text-white" : "text-slate-400 hover:text-slate-200"}`}
-                                onclick={() => updateUnionSelection(entry.index)}>
-                                {entry.label}
-                            </button>
-                        {/each}
-                    </div>
+                {#if anyOfOptions.length > 1}
+                    {@render renderUnionSelector(
+                        anyOfOptions,
+                        currentUnionIndex,
+                        pathKey,
+                        path,
+                        baseSchema,
+                        currentUnionValue,
+                    )}
                 {/if}
+            </div>
+        {/if}
+        {#if showHeaderlessUnionSelector}
+            <div class="flex justify-start">
+                {@render renderUnionSelector(
+                    anyOfOptions,
+                    currentUnionIndex,
+                    pathKey,
+                    path,
+                    baseSchema,
+                    currentUnionValue,
+                )}
             </div>
         {/if}
         {#if isBoolean}
@@ -433,7 +618,7 @@
                 value={String(value ?? resolvedSchema.default ?? enumOptions[0] ?? "")}
                 onchange={(event) =>
                     onChange(path, (event.currentTarget as HTMLSelectElement).value)}>
-                {#each enumOptions as option (`${String(path.join("."))}:${String(option)}`)}
+                {#each enumOptions as option (`${pathKey}:${String(option)}`)}
                     <option value={String(option)}>{String(option)}</option>
                 {/each}
             </select>
@@ -461,7 +646,7 @@
                 value={String(value ?? resolvedSchema.default ?? "")}
                 placeholder={resolvedSchema.default !== undefined
                     ? String(resolvedSchema.default)
-                    : primitiveTypes.has("null")
+                    : allowsNull
                       ? "Select None above to clear this field"
                       : ""}
                 onchange={(event) =>

--- a/frontend/src/lib/components/config/schema-form-node.svelte
+++ b/frontend/src/lib/components/config/schema-form-node.svelte
@@ -370,7 +370,8 @@
                 objectValue[key],
             )}
             {@const extraEntryCanAdd =
-                getAdditionalPropertiesSchema(extraEntrySchema, rootSchema) !== null}
+                getAdditionalPropertiesSchema(extraEntryResolvedSchema, rootSchema) !==
+                null}
             {@const extraEntryIsArray = extraEntryResolvedSchema.type === "array"}
             {@const extraEntryUnionOptions = getAnyOfOptions(
                 extraEntrySchema,
@@ -403,7 +404,7 @@
                                         : addObjectEntry(
                                               [...path, key],
                                               objectValue[key],
-                                              extraEntrySchema,
+                                              extraEntryResolvedSchema,
                                               "New entry name",
                                           )}>
                                 <CirclePlus class="inline h-4 w-4" />

--- a/frontend/src/lib/components/config/schema-form-node.svelte
+++ b/frontend/src/lib/components/config/schema-form-node.svelte
@@ -1,0 +1,471 @@
+<script lang="ts">
+    import { CirclePlus, Info, Trash2 } from "@lucide/svelte";
+
+    import Tooltip from "$lib/ui/tooltip.svelte";
+    import {
+        asRecord,
+        deepClone,
+        getAdditionalPropertiesSchema,
+        getAnyOfOptions,
+        getArrayItemSchema,
+        getObjectProperties,
+        getPreferredSchema,
+        getPrimitiveTypes,
+        getRequiredKeys,
+        humanizeKey,
+        makeDefaultValue,
+        resolveSchema,
+        type JsonPath,
+        type SchemaObject,
+    } from "./schema-form";
+    import SchemaFormNode from "./schema-form-node.svelte";
+
+    interface Props {
+        rootSchema: SchemaObject;
+        schema: SchemaObject;
+        value?: unknown;
+        path?: JsonPath;
+        label?: string;
+        required?: boolean;
+        depth?: number;
+        showHeader?: boolean;
+        addLabel?: string;
+        onChange: (path: JsonPath, value: unknown) => void;
+        onDelete?: (path: JsonPath) => void;
+    }
+
+    let {
+        rootSchema,
+        schema,
+        value = undefined,
+        path = [],
+        label = undefined,
+        required = false,
+        depth = 0,
+        showHeader = true,
+        addLabel = undefined,
+        onChange,
+        onDelete = undefined,
+    }: Props = $props();
+
+    function schemaMatchesValue(option: SchemaObject, candidate: unknown): boolean {
+        if (candidate === null) return option.type === "null";
+        if (Array.isArray(candidate)) return option.type === "array";
+        if (typeof candidate === "boolean") return option.type === "boolean";
+        if (typeof candidate === "number") {
+            return option.type === "number" || option.type === "integer";
+        }
+        if (typeof candidate === "string") return option.type === "string";
+        if (candidate && typeof candidate === "object") {
+            return option.type === "object" || typeof option.properties === "object";
+        }
+        return false;
+    }
+
+    function getUnionOptionLabel(option: SchemaObject, index: number): string {
+        if (typeof option.title === "string" && option.title.trim()) {
+            return option.title;
+        }
+
+        if (typeof option.type === "string" && option.type.trim()) {
+            return option.type;
+        }
+
+        return `option-${index + 1}`;
+    }
+
+    function getUnionOptionDefault(
+        option: SchemaObject,
+        parentSchema: SchemaObject,
+    ): unknown {
+        if (
+            parentSchema.default !== undefined &&
+            schemaMatchesValue(option, parentSchema.default)
+        ) {
+            return deepClone(parentSchema.default);
+        }
+
+        return makeDefaultValue(option, rootSchema);
+    }
+
+    const baseSchema = $derived(resolveSchema(schema, rootSchema));
+    const resolvedSchema = $derived(getPreferredSchema(schema, rootSchema, value));
+    const pathLeaf = $derived(path[path.length - 1]);
+    const anyOfOptions = $derived(getAnyOfOptions(schema, rootSchema));
+    const currentUnionValue = $derived(
+        value === undefined ? baseSchema.default : value,
+    );
+    const currentUnionIndex = $derived(
+        Math.max(
+            anyOfOptions.findIndex((option) =>
+                schemaMatchesValue(option, currentUnionValue),
+            ),
+            anyOfOptions.length > 0 ? 0 : -1,
+        ),
+    );
+    const unionEntries = $derived(
+        anyOfOptions.map((option, index) => ({
+            index,
+            label: getUnionOptionLabel(option, index),
+            schema: option,
+        })),
+    );
+    const title = $derived(
+        (typeof resolvedSchema.title === "string" && resolvedSchema.title) ||
+            label ||
+            (typeof pathLeaf === "string" ? humanizeKey(pathLeaf) : undefined),
+    );
+    const description = $derived(
+        typeof resolvedSchema.description === "string"
+            ? resolvedSchema.description
+            : null,
+    );
+    const enumOptions = $derived(
+        Array.isArray(resolvedSchema.enum)
+            ? resolvedSchema.enum.filter((entry): entry is string | number | boolean =>
+                  ["string", "number", "boolean"].includes(typeof entry),
+              )
+            : [],
+    );
+    const objectProperties = $derived(getObjectProperties(resolvedSchema, rootSchema));
+    const requiredKeys = $derived(getRequiredKeys(resolvedSchema, rootSchema));
+    const additionalSchema = $derived(
+        getAdditionalPropertiesSchema(resolvedSchema, rootSchema),
+    );
+    const objectValue = $derived(asRecord(value));
+    const knownKeys = $derived(Object.keys(objectProperties));
+    const extraKeys = $derived(
+        Object.keys(objectValue).filter((key) => !knownKeys.includes(key)),
+    );
+    const itemSchema = $derived(getArrayItemSchema(resolvedSchema, rootSchema));
+    const arrayValue = $derived(Array.isArray(value) ? value : []);
+    const primitiveTypes = $derived(getPrimitiveTypes(resolvedSchema, rootSchema));
+    const isObject = $derived(
+        resolvedSchema.type === "object" ||
+            knownKeys.length > 0 ||
+            additionalSchema !== null,
+    );
+    const isArray = $derived(resolvedSchema.type === "array");
+    const isBoolean = $derived(resolvedSchema.type === "boolean");
+    const isEnum = $derived(enumOptions.length > 0);
+    const isNull = $derived(resolvedSchema.type === "null");
+    const isNumeric = $derived(
+        resolvedSchema.type === "integer" || resolvedSchema.type === "number",
+    );
+
+    function promptAddObjectEntry() {
+        if (!additionalSchema) return;
+
+        const nextKey = window.prompt(`New ${addLabel ?? "entry"} name`);
+        const normalized = nextKey?.trim();
+        if (!normalized || objectValue[normalized] !== undefined) return;
+
+        onChange([...path, normalized], makeDefaultValue(additionalSchema, rootSchema));
+    }
+
+    function addArrayItem() {
+        onChange(path, [...arrayValue, makeDefaultValue(itemSchema, rootSchema)]);
+    }
+
+    function removeArrayItem(index: number) {
+        onChange(
+            path,
+            arrayValue.filter((_, entryIndex) => entryIndex !== index),
+        );
+    }
+
+    function updateUnionSelection(nextIndex: number) {
+        const entry = unionEntries[nextIndex];
+        if (!entry) return;
+
+        if (schemaMatchesValue(entry.schema, currentUnionValue)) return;
+        onChange(path, getUnionOptionDefault(entry.schema, baseSchema));
+    }
+
+    const wrapperClass = $derived(
+        depth === 0
+            ? "space-y-4"
+            : "space-y-4 rounded-md border border-slate-800/70 bg-slate-950/40 p-4",
+    );
+</script>
+
+{#if isObject}
+    <div class={wrapperClass}>
+        {#if showHeader && title}
+            <div class="space-y-1">
+                <div class="flex items-center justify-between gap-3">
+                    <div class="flex min-w-0 items-center gap-2">
+                        <h3 class="truncate text-sm font-semibold text-slate-100">
+                            {title}
+                        </h3>
+                        {#if description}
+                            <Tooltip
+                                class="z-20 max-w-xs rounded-md border border-slate-800/70 bg-slate-900/95 px-2 py-1.5 text-[11px] leading-relaxed text-slate-100 shadow-xl">
+                                {#snippet trigger()}
+                                    <button
+                                        type="button"
+                                        class="inline-flex h-5 w-5 items-center justify-center rounded-full text-slate-500 transition-colors hover:text-slate-200 focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:outline-none"
+                                        aria-label={`${title} description`}>
+                                        <Info class="h-3.5 w-3.5" />
+                                    </button>
+                                {/snippet}
+                                {description}
+                            </Tooltip>
+                        {/if}
+                        {#if required}
+                            <span
+                                class="rounded-full border border-blue-500/40 bg-blue-500/10 px-2 py-0.5 text-[10px] font-medium tracking-wide text-blue-200">
+                                Required
+                            </span>
+                        {/if}
+                    </div>
+                    {#if unionEntries.length > 1}
+                        <div
+                            class="inline-flex shrink-0 items-center rounded-md border border-slate-700/80 bg-slate-900/80 p-0.5">
+                            {#each unionEntries as entry (`${String(path.join("."))}:${entry.index}`)}
+                                <button
+                                    type="button"
+                                    class={`rounded-md px-2 py-0.5 text-[10px] font-medium transition ${entry.index === currentUnionIndex ? "bg-blue-600 text-white" : "text-slate-400 hover:text-slate-200"}`}
+                                    onclick={() => updateUnionSelection(entry.index)}>
+                                    {entry.label}
+                                </button>
+                            {/each}
+                        </div>
+                    {/if}
+                </div>
+            </div>
+        {/if}
+
+        {#each knownKeys as key (key)}
+            <SchemaFormNode
+                {rootSchema}
+                schema={objectProperties[key]}
+                value={objectValue[key]}
+                path={[...path, key]}
+                label={humanizeKey(key)}
+                required={requiredKeys.has(key)}
+                depth={depth + 1}
+                {onChange}
+                {onDelete} />
+        {/each}
+
+        {#each extraKeys as key (key)}
+            <div
+                class="space-y-3 rounded-md border border-slate-800/70 bg-slate-950/40 p-4">
+                <div class="flex items-center justify-between gap-3">
+                    <div>
+                        <h4 class="text-sm font-semibold text-slate-100">{key}</h4>
+                        <p class="text-xs text-slate-500">Custom entry</p>
+                    </div>
+                    {#if onDelete}
+                        <button
+                            type="button"
+                            class="inline-flex items-center gap-1 rounded-md border border-rose-900/70 bg-rose-950/40 px-2.5 py-1 text-[11px] font-medium text-rose-100 hover:bg-rose-900/40"
+                            onclick={() => onDelete?.([...path, key])}>
+                            <Trash2 class="h-3.5 w-3.5" /> Remove
+                        </button>
+                    {/if}
+                </div>
+                <SchemaFormNode
+                    {rootSchema}
+                    schema={additionalSchema ?? {}}
+                    value={objectValue[key]}
+                    path={[...path, key]}
+                    label={key}
+                    depth={depth + 1}
+                    showHeader={false}
+                    {onChange}
+                    {onDelete} />
+            </div>
+        {/each}
+
+        {#if additionalSchema}
+            <button
+                type="button"
+                class="inline-flex items-center gap-1 rounded-md border border-slate-700 bg-slate-900/70 px-3 py-1.5 text-xs font-medium text-slate-200 hover:bg-slate-800/70"
+                onclick={promptAddObjectEntry}>
+                <CirclePlus class="h-3.5 w-3.5" /> Add {addLabel ?? "entry"}
+            </button>
+        {/if}
+    </div>
+{:else if isArray}
+    <div class={wrapperClass}>
+        {#if showHeader && title}
+            <div class="space-y-1">
+                <div class="flex items-center justify-between gap-3">
+                    <div class="flex min-w-0 items-center gap-2">
+                        <h3 class="truncate text-sm font-semibold text-slate-100">
+                            {title}
+                        </h3>
+                        {#if description}
+                            <Tooltip
+                                class="z-20 max-w-xs rounded-md border border-slate-800/70 bg-slate-900/95 px-2 py-1.5 text-[11px] leading-relaxed text-slate-100 shadow-xl">
+                                {#snippet trigger()}
+                                    <button
+                                        type="button"
+                                        class="inline-flex h-5 w-5 items-center justify-center rounded-full text-slate-500 transition-colors hover:text-slate-200 focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:outline-none"
+                                        aria-label={`${title} description`}>
+                                        <Info class="h-3.5 w-3.5" />
+                                    </button>
+                                {/snippet}
+                                {description}
+                            </Tooltip>
+                        {/if}
+                        {#if required}
+                            <span
+                                class="rounded-full border border-blue-500/40 bg-blue-500/10 px-2 py-0.5 text-[10px] font-medium tracking-wide text-blue-200">
+                                Required
+                            </span>
+                        {/if}
+                    </div>
+                    {#if unionEntries.length > 1}
+                        <div
+                            class="inline-flex shrink-0 items-center rounded-md border border-slate-700/80 bg-slate-900/80 p-0.5">
+                            {#each unionEntries as entry (`${String(path.join("."))}:${entry.index}`)}
+                                <button
+                                    type="button"
+                                    class={`rounded-md px-2 py-0.5 text-[10px] font-medium transition ${entry.index === currentUnionIndex ? "bg-blue-600 text-white" : "text-slate-400 hover:text-slate-200"}`}
+                                    onclick={() => updateUnionSelection(entry.index)}>
+                                    {entry.label}
+                                </button>
+                            {/each}
+                        </div>
+                    {/if}
+                </div>
+            </div>
+        {/if}
+
+        <div class="flex flex-wrap gap-3">
+            {#each arrayValue as item, index (`${String(path.join("."))}:${index}`)}
+                <div
+                    class="min-w-[18rem] flex-1 space-y-3 rounded-md border border-slate-800/70 bg-slate-950/40 p-4">
+                    <div class="flex items-center justify-between gap-3">
+                        <p class="text-xs font-medium text-slate-300">
+                            Item {index + 1}
+                        </p>
+                        <button
+                            type="button"
+                            class="inline-flex items-center gap-1 rounded-md border border-rose-900/70 bg-rose-950/40 px-2.5 py-1 text-[11px] font-medium text-rose-100 hover:bg-rose-900/40"
+                            onclick={() => removeArrayItem(index)}>
+                            <Trash2 class="h-3.5 w-3.5" /> Remove
+                        </button>
+                    </div>
+                    <SchemaFormNode
+                        {rootSchema}
+                        schema={itemSchema}
+                        value={item}
+                        path={[...path, index]}
+                        depth={depth + 1}
+                        showHeader={false}
+                        {onChange}
+                        {onDelete} />
+                </div>
+            {/each}
+        </div>
+
+        <button
+            type="button"
+            class="inline-flex items-center gap-1 rounded-md border border-slate-700 bg-slate-900/70 px-3 py-1.5 text-xs font-medium text-slate-200 hover:bg-slate-800/70"
+            onclick={addArrayItem}>
+            <CirclePlus class="h-3.5 w-3.5" /> Add item
+        </button>
+    </div>
+{:else}
+    <label class="block space-y-1.5">
+        {#if title}
+            <div class="flex items-center justify-between gap-3">
+                <div
+                    class="flex min-w-0 items-center gap-2 text-xs font-medium tracking-wide text-slate-200">
+                    <span class="truncate">{title}</span>
+                    {#if description}
+                        <Tooltip
+                            class="z-20 max-w-xs rounded-md border border-slate-800/70 bg-slate-900/95 px-2 py-1.5 text-[11px] leading-relaxed text-slate-100 shadow-xl">
+                            {#snippet trigger()}
+                                <button
+                                    type="button"
+                                    class="inline-flex h-5 w-5 items-center justify-center rounded-full text-slate-500 transition-colors hover:text-slate-200 focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:outline-none"
+                                    aria-label={`${title} description`}>
+                                    <Info class="h-3.5 w-3.5" />
+                                </button>
+                            {/snippet}
+                            {description}
+                        </Tooltip>
+                    {/if}
+                    {#if required}
+                        <span
+                            class="rounded-full border border-blue-500/40 bg-blue-500/10 px-2 py-0.5 text-[10px] font-medium tracking-wide text-blue-200">
+                            Required
+                        </span>
+                    {/if}
+                </div>
+                {#if unionEntries.length > 1}
+                    <div
+                        class="inline-flex shrink-0 items-center rounded-md border border-slate-700/80 bg-slate-900/80 p-0.5">
+                        {#each unionEntries as entry (`${String(path.join("."))}:${entry.index}`)}
+                            <button
+                                type="button"
+                                class={`rounded-md px-2 py-0.5 text-[10px] font-medium transition ${entry.index === currentUnionIndex ? "bg-blue-600 text-white" : "text-slate-400 hover:text-slate-200"}`}
+                                onclick={() => updateUnionSelection(entry.index)}>
+                                {entry.label}
+                            </button>
+                        {/each}
+                    </div>
+                {/if}
+            </div>
+        {/if}
+        {#if isBoolean}
+            <label
+                class="flex items-center gap-3 rounded-md border border-slate-800/70 bg-slate-950/50 px-3 py-2 text-sm text-slate-100">
+                <input
+                    type="checkbox"
+                    checked={Boolean(value ?? resolvedSchema.default ?? false)}
+                    class="h-4 w-4 rounded border-slate-600 bg-slate-900 text-blue-500"
+                    onchange={(event) =>
+                        onChange(
+                            path,
+                            (event.currentTarget as HTMLInputElement).checked,
+                        )} />
+                <span>{title}</span>
+            </label>
+        {:else if isEnum}
+            <select
+                class="w-full rounded-md border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-slate-100 transition outline-none focus:border-blue-500"
+                value={String(value ?? resolvedSchema.default ?? enumOptions[0] ?? "")}
+                onchange={(event) =>
+                    onChange(path, (event.currentTarget as HTMLSelectElement).value)}>
+                {#each enumOptions as option (`${String(path.join("."))}:${String(option)}`)}
+                    <option value={String(option)}>{String(option)}</option>
+                {/each}
+            </select>
+        {:else if isNumeric}
+            <input
+                type="number"
+                class="w-full rounded-md border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-slate-100 transition outline-none focus:border-blue-500"
+                value={String(value ?? resolvedSchema.default ?? "")}
+                placeholder={resolvedSchema.default !== undefined
+                    ? String(resolvedSchema.default)
+                    : ""}
+                onchange={(event) => {
+                    const raw = (event.currentTarget as HTMLInputElement).value;
+                    onChange(path, raw === "" ? null : Number(raw));
+                }} />
+        {:else if isNull}
+            <div
+                class="rounded-md border border-slate-800/70 bg-slate-950/50 px-3 py-2 text-sm text-slate-300">
+                null
+            </div>
+        {:else}
+            <input
+                type={resolvedSchema.format === "password" ? "password" : "text"}
+                class="w-full rounded-md border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-slate-100 transition outline-none focus:border-blue-500"
+                value={String(value ?? resolvedSchema.default ?? "")}
+                placeholder={resolvedSchema.default !== undefined
+                    ? String(resolvedSchema.default)
+                    : primitiveTypes.has("null")
+                      ? "Select None above to clear this field"
+                      : ""}
+                onchange={(event) =>
+                    onChange(path, (event.currentTarget as HTMLInputElement).value)} />
+        {/if}
+    </label>
+{/if}

--- a/frontend/src/lib/components/config/schema-form.ts
+++ b/frontend/src/lib/components/config/schema-form.ts
@@ -2,8 +2,31 @@ export type JsonPath = Array<string | number>;
 
 export type SchemaObject = Record<string, unknown>;
 
+const flexibleJsonOptions: SchemaObject[] = [
+    { type: "string" },
+    { type: "number" },
+    { type: "boolean" },
+    { type: "object", additionalProperties: true },
+    { type: "array", items: {} },
+    { type: "null" },
+];
+
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function schemaMatchesValue(schema: SchemaObject, candidate: unknown): boolean {
+    if (candidate === null) return schema.type === "null";
+    if (Array.isArray(candidate)) return schema.type === "array";
+    if (typeof candidate === "boolean") return schema.type === "boolean";
+    if (typeof candidate === "number") {
+        return schema.type === "number" || schema.type === "integer";
+    }
+    if (typeof candidate === "string") return schema.type === "string";
+    if (isRecord(candidate)) {
+        return schema.type === "object" || isRecord(schema.properties);
+    }
+    return false;
 }
 
 function sortJson(value: unknown): unknown {
@@ -37,6 +60,21 @@ function resolveRef(rootSchema: unknown, ref: string): SchemaObject {
         current = current[segment];
     }
     return isRecord(current) ? current : {};
+}
+
+function supportsAnyJsonType(schema: SchemaObject): boolean {
+    return (
+        typeof schema.type !== "string" &&
+        !Array.isArray(schema.anyOf) &&
+        !Array.isArray(schema.enum) &&
+        !Array.isArray(schema.oneOf) &&
+        !Array.isArray(schema.allOf) &&
+        !Array.isArray(schema.prefixItems) &&
+        schema.const === undefined &&
+        !isRecord(schema.properties) &&
+        schema.additionalProperties === undefined &&
+        schema.items === undefined
+    );
 }
 
 export function resolveSchema(schema: unknown, rootSchema: unknown): SchemaObject {
@@ -120,22 +158,11 @@ export function getArrayItemSchema(schema: unknown, rootSchema: unknown): Schema
 
 export function getAnyOfOptions(schema: unknown, rootSchema: unknown): SchemaObject[] {
     const resolved = resolveSchema(schema, rootSchema);
-    return Array.isArray(resolved.anyOf)
-        ? resolved.anyOf.map((option) => resolveSchema(option, rootSchema))
-        : [];
-}
-
-export function getPrimitiveTypes(schema: unknown, rootSchema: unknown): Set<string> {
-    const resolved = resolveSchema(schema, rootSchema);
-    if (typeof resolved.type === "string") return new Set([resolved.type]);
-
-    const primitiveTypes = new Set<string>();
-    for (const option of getAnyOfOptions(resolved, rootSchema)) {
-        if (typeof option.type === "string") {
-            primitiveTypes.add(option.type);
-        }
+    if (Array.isArray(resolved.anyOf)) {
+        return resolved.anyOf.map((option) => resolveSchema(option, rootSchema));
     }
-    return primitiveTypes;
+
+    return supportsAnyJsonType(resolved) ? flexibleJsonOptions : [];
 }
 
 export function getPreferredSchema(
@@ -147,21 +174,9 @@ export function getPreferredSchema(
     const options = getAnyOfOptions(resolved, rootSchema);
     if (options.length === 0) return resolved;
 
-    const matcher = (option: SchemaObject) => {
-        if (value === null) return option.type === "null";
-        if (Array.isArray(value)) return option.type === "array";
-        if (isRecord(value))
-            return option.type === "object" || isRecord(option.properties);
-        if (typeof value === "boolean") return option.type === "boolean";
-        if (typeof value === "number") {
-            return option.type === "number" || option.type === "integer";
-        }
-        if (typeof value === "string") return option.type === "string";
-        return false;
-    };
-
     const preferred =
-        options.find(matcher) ?? options.find((option) => option.type !== "null");
+        options.find((option) => schemaMatchesValue(option, value)) ??
+        options.find((option) => option.type !== "null");
     return preferred ? { ...omitKeys(resolved, ["anyOf"]), ...preferred } : resolved;
 }
 

--- a/frontend/src/lib/components/config/schema-form.ts
+++ b/frontend/src/lib/components/config/schema-form.ts
@@ -1,0 +1,268 @@
+export type JsonPath = Array<string | number>;
+
+export type SchemaObject = Record<string, unknown>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sortJson(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map((entry) => sortJson(entry));
+    }
+
+    if (!isRecord(value)) return value;
+
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+        const entry = value[key];
+        if (entry !== undefined) {
+            sorted[key] = sortJson(entry);
+        }
+    }
+    return sorted;
+}
+
+function omitKeys(schema: SchemaObject, keys: string[]): SchemaObject {
+    return Object.fromEntries(
+        Object.entries(schema).filter(([key]) => !keys.includes(key)),
+    );
+}
+
+function resolveRef(rootSchema: unknown, ref: string): SchemaObject {
+    if (!ref.startsWith("#/")) return {};
+    let current: unknown = rootSchema;
+    for (const segment of ref.slice(2).split("/")) {
+        if (!isRecord(current)) return {};
+        current = current[segment];
+    }
+    return isRecord(current) ? current : {};
+}
+
+export function resolveSchema(schema: unknown, rootSchema: unknown): SchemaObject {
+    if (!isRecord(schema)) return {};
+
+    let resolved: SchemaObject = { ...schema };
+    const seen = new Set<string>();
+
+    while (typeof resolved.$ref === "string") {
+        const ref = resolved.$ref;
+        if (seen.has(ref)) break;
+        seen.add(ref);
+        resolved = { ...resolveRef(rootSchema, ref), ...omitKeys(resolved, ["$ref"]) };
+    }
+
+    return resolved;
+}
+
+export function asRecord(value: unknown): Record<string, unknown> {
+    return isRecord(value) ? value : {};
+}
+
+export function deepClone<T>(value: T): T {
+    return value === undefined ? value : JSON.parse(JSON.stringify(value));
+}
+
+export function stableStringify(value: unknown): string {
+    return JSON.stringify(sortJson(value));
+}
+
+export function humanizeKey(key: string): string {
+    const withSpaces = key
+        .replace(/_/g, " ")
+        .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+        .trim();
+    return withSpaces ? withSpaces[0].toUpperCase() + withSpaces.slice(1) : key;
+}
+
+export function getObjectProperties(
+    schema: unknown,
+    rootSchema: unknown,
+): Record<string, SchemaObject> {
+    const resolved = resolveSchema(schema, rootSchema);
+    const properties = resolved.properties;
+    if (!isRecord(properties)) return {};
+
+    return Object.fromEntries(
+        Object.entries(properties).map(([key, value]) => [
+            key,
+            resolveSchema(value, rootSchema),
+        ]),
+    );
+}
+
+export function getRequiredKeys(schema: unknown, rootSchema: unknown): Set<string> {
+    const resolved = resolveSchema(schema, rootSchema);
+    return new Set(
+        Array.isArray(resolved.required)
+            ? resolved.required.filter(
+                  (entry): entry is string => typeof entry === "string",
+              )
+            : [],
+    );
+}
+
+export function getAdditionalPropertiesSchema(
+    schema: unknown,
+    rootSchema: unknown,
+): SchemaObject | null {
+    const resolved = resolveSchema(schema, rootSchema);
+    if (resolved.additionalProperties === true) return {};
+    return isRecord(resolved.additionalProperties)
+        ? resolveSchema(resolved.additionalProperties, rootSchema)
+        : null;
+}
+
+export function getArrayItemSchema(schema: unknown, rootSchema: unknown): SchemaObject {
+    const resolved = resolveSchema(schema, rootSchema);
+    return resolveSchema(resolved.items, rootSchema);
+}
+
+export function getAnyOfOptions(schema: unknown, rootSchema: unknown): SchemaObject[] {
+    const resolved = resolveSchema(schema, rootSchema);
+    return Array.isArray(resolved.anyOf)
+        ? resolved.anyOf.map((option) => resolveSchema(option, rootSchema))
+        : [];
+}
+
+export function getPrimitiveTypes(schema: unknown, rootSchema: unknown): Set<string> {
+    const resolved = resolveSchema(schema, rootSchema);
+    if (typeof resolved.type === "string") return new Set([resolved.type]);
+
+    const primitiveTypes = new Set<string>();
+    for (const option of getAnyOfOptions(resolved, rootSchema)) {
+        if (typeof option.type === "string") {
+            primitiveTypes.add(option.type);
+        }
+    }
+    return primitiveTypes;
+}
+
+export function getPreferredSchema(
+    schema: unknown,
+    rootSchema: unknown,
+    value: unknown,
+): SchemaObject {
+    const resolved = resolveSchema(schema, rootSchema);
+    const options = getAnyOfOptions(resolved, rootSchema);
+    if (options.length === 0) return resolved;
+
+    const matcher = (option: SchemaObject) => {
+        if (value === null) return option.type === "null";
+        if (Array.isArray(value)) return option.type === "array";
+        if (isRecord(value))
+            return option.type === "object" || isRecord(option.properties);
+        if (typeof value === "boolean") return option.type === "boolean";
+        if (typeof value === "number") {
+            return option.type === "number" || option.type === "integer";
+        }
+        if (typeof value === "string") return option.type === "string";
+        return false;
+    };
+
+    const preferred =
+        options.find(matcher) ?? options.find((option) => option.type !== "null");
+    return preferred ? { ...omitKeys(resolved, ["anyOf"]), ...preferred } : resolved;
+}
+
+export function makeDefaultValue(schema: unknown, rootSchema: unknown): unknown {
+    const resolved = getPreferredSchema(schema, rootSchema, undefined);
+    if (resolved.default !== undefined) {
+        return deepClone(resolved.default);
+    }
+
+    if (Array.isArray(resolved.enum) && resolved.enum.length > 0) {
+        return deepClone(resolved.enum[0]);
+    }
+
+    switch (resolved.type) {
+        case "object":
+            return {};
+        case "array":
+            return [];
+        case "boolean":
+            return false;
+        case "integer":
+        case "number":
+            return 0;
+        case "null":
+            return null;
+        default:
+            return "";
+    }
+}
+
+export function setAtPath(
+    root: Record<string, unknown>,
+    path: JsonPath,
+    value: unknown,
+): Record<string, unknown> {
+    const clone = deepClone(root ?? {}) as Record<string, unknown>;
+    if (path.length === 0) {
+        return asRecord(value);
+    }
+
+    let current: unknown = clone;
+    for (let index = 0; index < path.length - 1; index += 1) {
+        const segment = path[index];
+        const nextSegment = path[index + 1];
+
+        if (typeof segment === "number") {
+            const list = Array.isArray(current) ? current : [];
+            list[segment] ??=
+                typeof nextSegment === "number" ? [] : ({} as Record<string, unknown>);
+            current = list[segment];
+            continue;
+        }
+
+        const record = asRecord(current);
+        const existing = record[segment];
+        record[segment] =
+            existing ??
+            (typeof nextSegment === "number" ? [] : ({} as Record<string, unknown>));
+        current = record[segment];
+    }
+
+    const last = path[path.length - 1];
+    if (typeof last === "number") {
+        const list = Array.isArray(current) ? current : [];
+        list[last] = value;
+        return clone;
+    }
+
+    asRecord(current)[last] = value;
+    return clone;
+}
+
+export function removeAtPath(
+    root: Record<string, unknown>,
+    path: JsonPath,
+): Record<string, unknown> {
+    const clone = deepClone(root ?? {}) as Record<string, unknown>;
+    if (path.length === 0) return {};
+
+    let current: unknown = clone;
+    for (let index = 0; index < path.length - 1; index += 1) {
+        const segment = path[index];
+        if (typeof segment === "number") {
+            if (!Array.isArray(current)) return clone;
+            current = current[segment];
+            continue;
+        }
+        if (!isRecord(current)) return clone;
+        current = current[segment];
+    }
+
+    const last = path[path.length - 1];
+    if (typeof last === "number") {
+        if (Array.isArray(current)) {
+            current.splice(last, 1);
+        }
+        return clone;
+    }
+
+    if (isRecord(current)) {
+        delete current[last];
+    }
+    return clone;
+}

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -190,10 +190,17 @@ export interface ConfigDocumentResponse {
     content: string;
     mtime?: number | null;
     schema?: Record<string, unknown> | null;
+    settings?: Record<string, unknown> | null;
+    settings_error?: string | null;
 }
 
 export interface ConfigDocumentUpdateRequest {
     content: string;
+    expected_mtime?: number | null;
+}
+
+export interface ConfigStructuredUpdateRequest {
+    settings: Record<string, unknown>;
     expected_mtime?: number | null;
 }
 

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -2,6 +2,7 @@
     import { onMount } from "svelte";
 
     import {
+        FileCodeCorner,
         Info,
         Languages,
         LoaderCircle,
@@ -10,11 +11,21 @@
         Settings as SettingsIcon,
         TriangleAlert,
     } from "@lucide/svelte";
+    import { Tabs } from "bits-ui";
 
     import YamlEditor from "$lib/components/code-editor/yaml-editor.svelte";
+    import {
+        deepClone,
+        humanizeKey,
+        removeAtPath,
+        setAtPath,
+        stableStringify,
+    } from "$lib/components/config/schema-form";
+    import SchemaFormNode from "$lib/components/config/schema-form-node.svelte";
     import type {
         ConfigDocumentResponse,
         ConfigDocumentUpdateRequest,
+        ConfigStructuredUpdateRequest,
         ConfigUpdateResponse,
     } from "$lib/types/api";
     import {
@@ -37,9 +48,36 @@
     let editorValue = $state("");
     let initialValue = $state("");
     let configSchema = $state<Record<string, unknown> | null>(null);
+    let uiValue = $state<Record<string, unknown>>({});
+    let initialUiValue = $state<Record<string, unknown>>({});
+    let uiSettingsError: string | null = $state(null);
     let mtime: number | null = null;
+    let activeTab = $state<"ui" | "yaml">("ui");
+    let activeUiSection = $state<"app" | "global" | "profiles">("app");
 
-    const hasChanges = $derived(editorValue !== initialValue);
+    const hasYamlChanges = $derived(editorValue !== initialValue);
+    const hasUiChanges = $derived(
+        stableStringify(uiValue) !== stableStringify(initialUiValue),
+    );
+    const hasChanges = $derived(activeTab === "yaml" ? hasYamlChanges : hasUiChanges);
+    const uiEditorAvailable = $derived(configSchema !== null && !uiSettingsError);
+    const topLevelSchemaProperties = $derived(
+        (configSchema?.properties as Record<string, unknown> | undefined) ?? {},
+    );
+    const globalSettingsSchema = $derived(
+        (topLevelSchemaProperties.global_config as
+            | Record<string, unknown>
+            | undefined) ?? null,
+    );
+    const profilesSchema = $derived(
+        (topLevelSchemaProperties.profiles as Record<string, unknown> | undefined) ??
+            null,
+    );
+    const appSettingEntries = $derived(
+        Object.entries(topLevelSchemaProperties).filter(
+            ([fieldName]) => fieldName !== "global_config" && fieldName !== "profiles",
+        ),
+    );
 
     let restartPollGeneration = 0;
 
@@ -135,6 +173,9 @@
             editorValue = configPayload.content ?? "";
             initialValue = editorValue;
             configSchema = configPayload.schema ?? null;
+            uiValue = deepClone(configPayload.settings ?? {});
+            initialUiValue = deepClone(configPayload.settings ?? {});
+            uiSettingsError = configPayload.settings_error ?? null;
             mtime = configPayload.mtime ?? null;
         } catch (error) {
             loadError = formatError(error);
@@ -171,6 +212,56 @@
         } finally {
             saving = false;
         }
+    }
+
+    async function saveUiConfig() {
+        if (saving || loading || configAccessBlocked || !uiEditorAvailable) return;
+        saveError = null;
+
+        const payload: ConfigStructuredUpdateRequest = {
+            settings: uiValue,
+            expected_mtime: mtime ?? undefined,
+        };
+
+        saving = true;
+        try {
+            const response = await apiJson<ConfigUpdateResponse>(
+                "/api/config/structured",
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(payload),
+                },
+            );
+            toast(
+                response.requires_restart
+                    ? "Configuration saved. A restart is required to apply all changes."
+                    : "Configuration saved and applied.",
+                "success",
+            );
+            await loadConfig();
+        } catch (error) {
+            saveError = formatError(error);
+        } finally {
+            saving = false;
+        }
+    }
+
+    async function handleSave() {
+        if (activeTab === "yaml") {
+            await saveConfig();
+            return;
+        }
+
+        if (
+            !window.confirm(
+                "Saving through the guided editor rewrites the YAML document and discards all comments. Continue?",
+            )
+        ) {
+            return;
+        }
+
+        await saveUiConfig();
     }
 
     async function restartServer() {
@@ -212,7 +303,53 @@
     }
 
     function revertChanges() {
+        if (activeTab === "yaml") {
+            editorValue = initialValue;
+        } else {
+            uiValue = deepClone(initialUiValue);
+        }
+        saveError = null;
+    }
+
+    function resetDrafts() {
         editorValue = initialValue;
+        uiValue = deepClone(initialUiValue);
+        saveError = null;
+    }
+
+    function switchTab(nextTab: string) {
+        if (nextTab !== "ui" && nextTab !== "yaml") return;
+        if (nextTab === activeTab) return;
+
+        const dirty = hasYamlChanges || hasUiChanges;
+        if (
+            dirty &&
+            !window.confirm(
+                "Switching tabs discards unsaved edits in both editors. Continue?",
+            )
+        ) {
+            return;
+        }
+
+        resetDrafts();
+        activeTab = nextTab;
+    }
+
+    function switchUiSection(nextTab: string) {
+        if (nextTab !== "app" && nextTab !== "global" && nextTab !== "profiles") {
+            return;
+        }
+
+        activeUiSection = nextTab;
+    }
+
+    function updateUiValue(path: Array<string | number>, nextValue: unknown) {
+        uiValue = setAtPath(uiValue, path, nextValue);
+        saveError = null;
+    }
+
+    function deleteUiValue(path: Array<string | number>) {
+        uiValue = removeAtPath(uiValue, path);
         saveError = null;
     }
 
@@ -249,99 +386,82 @@
 </script>
 
 <div class="space-y-3">
-    <div class="flex flex-wrap items-center justify-between gap-3">
-        <div class="flex items-center gap-2 text-slate-200">
-            <SettingsIcon class="h-5 w-5 text-slate-400" />
-            <div>
-                <h2 class="text-base font-semibold">Configuration</h2>
-                <p class="text-xs text-slate-500">
-                    Edit your AniBridge configuration file directly.
-                </p>
+    <div class="space-y-2">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div class="space-y-1 sm:flex-1">
+                <div class="flex items-center gap-2">
+                    <SettingsIcon class="h-4 w-4 text-slate-300" />
+                    <h2 class="text-lg font-semibold text-slate-100">Configuration</h2>
+                </div>
+                <p class="text-xs text-slate-400">Edit your AniBridge configuration.</p>
+            </div>
+            <div class="flex flex-wrap gap-2 text-xs">
+                <button
+                    type="button"
+                    class="inline-flex items-center gap-1 rounded-md border border-slate-700 bg-slate-900/60 px-3 py-1.5 text-slate-100 transition-colors hover:bg-slate-800/60"
+                    onclick={loadConfig}
+                    disabled={loading || saving || restarting}>
+                    <RefreshCw class="h-3.5 w-3.5" /> Reload
+                </button>
+                <a
+                    href="https://anibridge.eliasbenb.dev"
+                    target="_blank"
+                    rel="noreferrer"
+                    class="inline-flex items-center gap-1 rounded-md border border-slate-700 bg-slate-900/60 px-3 py-1.5 text-slate-100 transition-colors hover:bg-slate-800/60">
+                    <Info class="h-3.5 w-3.5" /> Docs
+                </a>
+                <button
+                    type="button"
+                    class="inline-flex items-center gap-1 rounded-md border border-slate-700 bg-slate-900/60 px-3 py-1.5 text-slate-100 transition-colors hover:bg-slate-800/60 disabled:opacity-50"
+                    onclick={revertChanges}
+                    disabled={loading ||
+                        saving ||
+                        restarting ||
+                        configAccessBlocked ||
+                        !hasChanges}>
+                    Revert
+                </button>
+                <button
+                    type="button"
+                    class="inline-flex items-center gap-1 rounded-md border border-amber-500 bg-amber-600 px-4 py-1.5 font-semibold text-white transition-colors hover:bg-amber-500 disabled:opacity-50"
+                    onclick={restartServer}
+                    disabled={loading || saving || restarting}>
+                    <RefreshCw
+                        class={`h-3.5 w-3.5 ${restarting ? "animate-spin" : ""}`} />
+                    {restarting ? "Restarting…" : "Restart Server"}
+                </button>
+                <button
+                    type="button"
+                    class="inline-flex items-center gap-1 rounded-md border border-blue-500 bg-blue-600 px-4 py-1.5 font-semibold text-white transition-colors hover:bg-blue-500 disabled:opacity-50"
+                    onclick={handleSave}
+                    disabled={loading ||
+                        saving ||
+                        restarting ||
+                        configAccessBlocked ||
+                        !hasChanges}>
+                    <Save class="h-3.5 w-3.5" />
+                    {saving ? "Saving…" : "Save"}
+                </button>
             </div>
         </div>
-        <div class="flex flex-wrap gap-2 text-xs">
-            <button
-                type="button"
-                class="inline-flex items-center gap-1 rounded border border-slate-700 bg-slate-900/60 px-3 py-1 text-slate-100 hover:bg-slate-800/60"
-                onclick={loadConfig}
-                disabled={loading || saving || restarting}>
-                <RefreshCw class="h-3.5 w-3.5" /> Reload
-            </button>
-            <a
-                href="https://anibridge.eliasbenb.dev"
-                target="_blank"
-                rel="noreferrer"
-                class="inline-flex items-center gap-1 rounded border border-slate-700 bg-slate-900/60 px-3 py-1 text-slate-100 hover:bg-slate-800/60">
-                <Info class="h-3.5 w-3.5" /> Docs
-            </a>
-            <button
-                type="button"
-                class="inline-flex items-center gap-1 rounded border border-slate-700 bg-slate-900/60 px-3 py-1 text-slate-100 hover:bg-slate-800/60 disabled:opacity-50"
-                onclick={revertChanges}
-                disabled={loading ||
-                    saving ||
-                    restarting ||
-                    configAccessBlocked ||
-                    !hasChanges}>
-                Revert
-            </button>
-            <button
-                type="button"
-                class="inline-flex items-center gap-1 rounded border border-amber-500 bg-amber-600 px-4 py-1 font-semibold text-white hover:bg-amber-500 disabled:opacity-50"
-                onclick={restartServer}
-                disabled={loading || saving || restarting}>
-                <RefreshCw class={`h-3.5 w-3.5 ${restarting ? "animate-spin" : ""}`} />
-                {restarting ? "Restarting…" : "Restart Server"}
-            </button>
-            <button
-                type="button"
-                class="inline-flex items-center gap-1 rounded border border-blue-500 bg-blue-600 px-4 py-1 font-semibold text-white hover:bg-blue-500 disabled:opacity-50"
-                onclick={saveConfig}
-                disabled={loading ||
-                    saving ||
-                    restarting ||
-                    configAccessBlocked ||
-                    !hasChanges}>
-                <Save class="h-3.5 w-3.5" />
-                {saving ? "Saving…" : "Save"}
-            </button>
-        </div>
-    </div>
-
-    <div
-        class="rounded border border-slate-800 bg-slate-950/60 p-4 text-xs text-slate-300">
-        <p>
-            <span class="font-semibold text-slate-100">Configuration file:</span>
-            <code
-                class="ml-2 rounded bg-slate-900 px-1 py-0.5 text-[11px] text-slate-200">
-                {configPath || "(not set)"}
-            </code>
-        </p>
-        <p class="mt-1 text-slate-500">
-            {#if fileExists}
-                The existing file will be overwritten when you save.
-            {:else}
-                A new configuration file will be created when you save.
-            {/if}
-        </p>
     </div>
 
     {#if loadError}
         <div
-            class="flex items-center gap-2 rounded border border-rose-900/60 bg-rose-950/60 px-3 py-2 text-xs text-rose-100">
+            class="flex items-center gap-2 rounded-md border border-rose-900/60 bg-rose-950/60 px-3 py-2 text-xs text-rose-100">
             <TriangleAlert class="h-3.5 w-3.5" /> Failed to load configuration: {loadError}
         </div>
     {/if}
 
     {#if configAccessBlocked}
         <div
-            class="rounded border border-amber-900/70 bg-amber-950/50 px-3 py-2 text-xs text-amber-100">
+            class="rounded-md border border-amber-900/70 bg-amber-950/50 px-3 py-2 text-xs text-amber-100">
             <p class="font-medium">Configuration editor is blocked.</p>
             <p class="mt-1 text-amber-200/90">
-                Configure <code class="rounded bg-amber-900/40 px-1"
+                Configure <code class="rounded-md bg-amber-900/40 px-1"
                     >web.basic_auth</code>
                 or explicitly set
-                <code class="rounded bg-amber-900/40 px-1"
+                <code class="rounded-md bg-amber-900/40 px-1"
                     >web.allow_config_without_auth: true</code>
                 to allow unauthenticated access.
             </p>
@@ -350,7 +470,7 @@
 
     {#if saveError}
         <div
-            class="flex items-center gap-2 rounded border border-rose-900/60 bg-rose-950/60 px-3 py-2 text-xs text-rose-100">
+            class="flex items-center gap-2 rounded-md border border-rose-900/60 bg-rose-950/60 px-3 py-2 text-xs text-rose-100">
             <TriangleAlert class="h-3.5 w-3.5" />
             {saveError}
         </div>
@@ -358,43 +478,233 @@
 
     {#if restarting || restartNotice}
         <div
-            class="flex items-center gap-2 rounded border border-amber-900/70 bg-amber-950/50 px-3 py-2 text-xs text-amber-100">
+            class="flex items-center gap-2 rounded-md border border-amber-900/70 bg-amber-950/50 px-3 py-2 text-xs text-amber-100">
             <LoaderCircle class={`h-3.5 w-3.5 ${restarting ? "animate-spin" : ""}`} />
             {restartNotice ?? "Restarting AniBridge..."}
         </div>
     {/if}
 
     <div class="space-y-2">
-        <div class="flex items-center gap-2 text-slate-300">
-            <Info class="h-4 w-4 text-slate-500" />
-            <p class="text-xs text-slate-400">
-                Paste or edit the YAML content below. Saving replaces the existing file
-                and requires restarting AniBridge to apply changes.
-            </p>
-        </div>
+        <Tabs.Root
+            value={activeTab}
+            onValueChange={switchTab}
+            class="space-y-4">
+            <Tabs.List
+                class="inline-flex items-center gap-1 rounded-md border border-slate-800/70 bg-slate-950/50 p-1">
+                <Tabs.Trigger
+                    value="ui"
+                    class="inline-flex h-9 items-center gap-1 rounded-md px-4 text-xs font-medium text-slate-400 transition-colors hover:text-slate-200 data-[state=active]:bg-slate-800/80 data-[state=active]:text-slate-100">
+                    <SettingsIcon class="h-4 w-4" /> UI
+                </Tabs.Trigger>
+                <Tabs.Trigger
+                    value="yaml"
+                    class="inline-flex h-9 items-center gap-1 rounded-md px-4 text-xs font-medium text-slate-400 transition-colors hover:text-slate-200 data-[state=active]:bg-slate-800/80 data-[state=active]:text-slate-100">
+                    <FileCodeCorner class="h-4 w-4" /> YAML
+                </Tabs.Trigger>
+            </Tabs.List>
+        </Tabs.Root>
+
         <div
-            class="rounded-lg border border-slate-800 bg-slate-950/70 p-2 shadow-inner">
-            {#if loading}
+            class="rounded-md border border-sky-900/70 bg-sky-950/30 p-4 text-xs text-sky-100">
+            <div class="flex items-start gap-3">
+                <Info class="mt-0.5 h-4 w-4 shrink-0 text-sky-300" />
+                <div class="min-w-0 space-y-1.5">
+                    <p>
+                        <span class="font-semibold text-sky-100"
+                            >Configuration file:</span>
+                        <code
+                            class="ml-2 rounded-md bg-sky-950/60 px-1.5 py-0.5 text-[11px] text-sky-50">
+                            {configPath || "(not set)"}
+                        </code>
+                    </p>
+                    <p class="text-sky-200/80">
+                        {#if fileExists}
+                            The existing file will be overwritten when you save.
+                        {:else}
+                            A new configuration file will be created when you save.
+                        {/if}
+                    </p>
+                    <p class="text-[11px] text-sky-200/80">
+                        {#if uiSettingsError}
+                            Guided UI is unavailable until the YAML parses cleanly.
+                        {:else if !configSchema}
+                            Guided UI availability is still loading.
+                        {/if}
+                        {#if hasChanges}
+                            <span
+                                class={uiSettingsError || !configSchema
+                                    ? "ml-2 text-blue-200"
+                                    : "text-blue-200"}>
+                                Unsaved {activeTab === "yaml" ? "YAML" : "UI"}
+                                changes.
+                            </span>
+                        {/if}
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        {#if activeTab === "ui"}
+            {#if uiSettingsError}
                 <div
-                    class="flex items-center justify-center gap-2 py-32 text-xs text-slate-400">
+                    class="flex items-center gap-2 rounded-md border border-amber-900/70 bg-amber-950/50 px-3 py-2 text-xs text-amber-100">
+                    <TriangleAlert class="h-3.5 w-3.5" />
+                    Guided UI is unavailable until the YAML parses cleanly: {uiSettingsError}
+                </div>
+            {:else if loading}
+                <div
+                    class="flex items-center justify-center gap-2 rounded-md border border-slate-800 bg-slate-950/70 py-32 text-xs text-slate-400 shadow-inner">
                     <LoaderCircle class="h-4 w-4 animate-spin" /> Loading configuration…
                 </div>
-            {:else}
+            {:else if configSchema}
                 <div
-                    class="h-[60vh] overflow-hidden rounded-md border border-slate-900/80">
-                    <YamlEditor
-                        bind:value={editorValue}
-                        theme="dark"
-                        fontSize="13px"
-                        readOnly={saving || configAccessBlocked}
-                        schemaObject={configSchema ?? undefined}
-                        fileUri={configPath ? `file://${configPath}` : undefined} />
+                    class="space-y-4 rounded-md border border-slate-800/80 bg-slate-950/60 p-4 shadow-sm">
+                    <Tabs.Root
+                        value={activeUiSection}
+                        onValueChange={switchUiSection}
+                        class="space-y-4">
+                        <Tabs.List class="grid gap-2 sm:grid-cols-3">
+                            <Tabs.Trigger
+                                value="app"
+                                class="flex rounded-md border border-slate-800/70 bg-slate-950/40 p-3 text-left transition-colors hover:border-slate-700/80 hover:bg-slate-900/70 data-[state=active]:border-blue-500/40 data-[state=active]:bg-slate-900 data-[state=active]:shadow-sm">
+                                <div class="space-y-1">
+                                    <div class="text-xs font-semibold text-slate-100">
+                                        App Settings
+                                    </div>
+                                    <p
+                                        class="text-[11px] leading-relaxed text-slate-400">
+                                        App-wide settings.
+                                    </p>
+                                </div>
+                            </Tabs.Trigger>
+                            <Tabs.Trigger
+                                value="global"
+                                class="flex rounded-md border border-slate-800/70 bg-slate-950/40 p-3 text-left transition-colors hover:border-slate-700/80 hover:bg-slate-900/70 data-[state=active]:border-blue-500/40 data-[state=active]:bg-slate-900 data-[state=active]:shadow-sm">
+                                <div class="space-y-1">
+                                    <div class="text-xs font-semibold text-slate-100">
+                                        Global Settings
+                                    </div>
+                                    <p
+                                        class="text-[11px] leading-relaxed text-slate-400">
+                                        Shared defaults inherited by every configured
+                                        profile.
+                                    </p>
+                                </div>
+                            </Tabs.Trigger>
+                            <Tabs.Trigger
+                                value="profiles"
+                                class="flex rounded-md border border-slate-800/70 bg-slate-950/40 p-3 text-left transition-colors hover:border-slate-700/80 hover:bg-slate-900/70 data-[state=active]:border-blue-500/40 data-[state=active]:bg-slate-900 data-[state=active]:shadow-sm">
+                                <div class="space-y-1">
+                                    <div class="text-xs font-semibold text-slate-100">
+                                        Profile Settings
+                                    </div>
+                                    <p
+                                        class="text-[11px] leading-relaxed text-slate-400">
+                                        Provider connections and per-profile sync
+                                        behavior.
+                                    </p>
+                                </div>
+                            </Tabs.Trigger>
+                        </Tabs.List>
+                    </Tabs.Root>
+
+                    {#if activeUiSection === "app"}
+                        <section
+                            class="space-y-4 rounded-md border border-slate-800/70 bg-slate-950/40 p-4">
+                            {#if appSettingEntries.length === 0}
+                                <div
+                                    class="rounded-md border border-slate-800/70 bg-slate-950/50 px-3 py-4 text-xs text-slate-400">
+                                    No app-level settings are available in the current
+                                    schema.
+                                </div>
+                            {:else}
+                                <div class="space-y-4">
+                                    {#each appSettingEntries as [fieldName, fieldSchema] (fieldName)}
+                                        <SchemaFormNode
+                                            rootSchema={configSchema}
+                                            schema={fieldSchema as Record<
+                                                string,
+                                                unknown
+                                            >}
+                                            value={uiValue[fieldName]}
+                                            path={[fieldName]}
+                                            label={humanizeKey(fieldName)}
+                                            onChange={updateUiValue}
+                                            onDelete={deleteUiValue} />
+                                    {/each}
+                                </div>
+                            {/if}
+                        </section>
+                    {:else if activeUiSection === "global"}
+                        <section
+                            class="space-y-4 rounded-md border border-slate-800/70 bg-slate-950/40 p-4">
+                            {#if globalSettingsSchema}
+                                <SchemaFormNode
+                                    rootSchema={configSchema}
+                                    schema={globalSettingsSchema}
+                                    value={uiValue.global_config}
+                                    path={["global_config"]}
+                                    label="Global Settings"
+                                    onChange={updateUiValue}
+                                    onDelete={deleteUiValue} />
+                            {:else}
+                                <div
+                                    class="rounded-md border border-slate-800/70 bg-slate-950/50 px-3 py-4 text-xs text-slate-400">
+                                    Global settings are not defined in the current
+                                    schema.
+                                </div>
+                            {/if}
+                        </section>
+                    {:else}
+                        <section
+                            class="space-y-4 rounded-md border border-slate-800/70 bg-slate-950/40 p-4">
+                            {#if profilesSchema}
+                                <SchemaFormNode
+                                    rootSchema={configSchema}
+                                    schema={profilesSchema}
+                                    value={uiValue.profiles}
+                                    path={["profiles"]}
+                                    label="Profiles"
+                                    addLabel="profile"
+                                    onChange={updateUiValue}
+                                    onDelete={deleteUiValue} />
+                            {:else}
+                                <div
+                                    class="rounded-md border border-slate-800/70 bg-slate-950/50 px-3 py-4 text-xs text-slate-400">
+                                    Profile settings are not defined in the current
+                                    schema.
+                                </div>
+                            {/if}
+                        </section>
+                    {/if}
                 </div>
             {/if}
-        </div>
+        {:else}
+            <div
+                class="rounded-md border border-slate-800 bg-slate-950/70 p-2 shadow-inner">
+                {#if loading}
+                    <div
+                        class="flex items-center justify-center gap-2 py-32 text-xs text-slate-400">
+                        <LoaderCircle class="h-4 w-4 animate-spin" /> Loading configuration…
+                    </div>
+                {:else}
+                    <div
+                        class="h-[60vh] overflow-hidden rounded-md border border-slate-900/80">
+                        <YamlEditor
+                            bind:value={editorValue}
+                            theme="dark"
+                            fontSize="13px"
+                            readOnly={saving || configAccessBlocked}
+                            schemaObject={configSchema ?? undefined}
+                            fileUri={configPath ? `file://${configPath}` : undefined} />
+                    </div>
+                {/if}
+            </div>
+        {/if}
+
         {#if hasChanges}
             <p class="text-[11px] text-slate-400">
-                Unsaved changes detected. Save to persist updates.
+                Unsaved changes detected in the {activeTab === "yaml" ? "YAML" : "UI"} editor.
             </p>
         {/if}
     </div>

--- a/src/anibridge/app/web/routes/api/config.py
+++ b/src/anibridge/app/web/routes/api/config.py
@@ -46,6 +46,32 @@ class ConfigDocumentResponse(msgspec.Struct):
             examples=[{"title": "AnibridgeConfig", "type": "object"}],
         ),
     ]
+    settings: (
+        Annotated[
+            dict[str, object],
+            msgspec.Meta(
+                description=(
+                    "Parsed configuration mapping for the guided UI. Null when the "
+                    "current YAML cannot be parsed into a mapping."
+                ),
+                examples=[{"global_config": {}, "profiles": {}}],
+            ),
+        ]
+        | None
+    ) = None
+    settings_error: (
+        Annotated[
+            str,
+            msgspec.Meta(
+                description=(
+                    "Parsing error for the guided UI when the current YAML cannot be "
+                    "represented as structured settings."
+                ),
+                examples=["Invalid YAML syntax: expected <block end>"],
+            ),
+        ]
+        | None
+    ) = None
     mtime: (
         Annotated[
             int,
@@ -78,6 +104,30 @@ class ConfigDocumentUpdateRequest(msgspec.Struct):
                 description=(
                     "Last known file modification time used for "
                     "optimistic concurrency checks."
+                ),
+                examples=[1715179200000],
+            ),
+        ]
+        | None
+    ) = None
+
+
+class ConfigStructuredUpdateRequest(msgspec.Struct):
+    settings: Annotated[
+        dict[str, object],
+        msgspec.Meta(
+            description="Structured AniBridge configuration payload for the guided UI.",
+            examples=[{"global_config": {}, "profiles": {}}],
+        ),
+    ]
+    expected_mtime: (
+        Annotated[
+            int,
+            msgspec.Meta(
+                ge=0,
+                description=(
+                    "Last known file modification time used for optimistic "
+                    "concurrency checks."
                 ),
                 examples=[1715179200000],
             ),
@@ -219,18 +269,62 @@ async def update_configuration(
     )
 
 
-@get(path="/openapi.json", sync_to_thread=True)
-def get_openapi_schema() -> dict[str, object]:
-    """Return the OpenAPI schema for the configuration API.
+@post(path="/structured", status_code=200)
+async def update_configuration_structured(
+    data: Annotated[ConfigStructuredUpdateRequest, Body()],
+) -> ConfigUpdateResponse:
+    """Persist the provided structured configuration payload.
+
+    Args:
+        data (ConfigStructuredUpdateRequest): The structured configuration update.
 
     Returns:
-        dict: OpenAPI schema
+        ConfigUpdateResponse: The result of the update operation.
     """
     require_config_api_access()
-    return AnibridgeConfig.model_json_schema()
+    try:
+        (
+            config,
+            requires_restart,
+            mtime,
+        ) = await get_configuration_service().save_settings_payload(
+            data.settings,
+            expected_mtime=data.expected_mtime,
+        )
+    except FileExistsError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=str(exc),
+        ) from exc
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=str(exc.errors()),
+        ) from exc
+    except SchedulerUnavailableError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=str(exc),
+        ) from exc
+
+    return ConfigUpdateResponse(
+        ok=True,
+        profiles=sorted(config.profiles.keys()),
+        requires_restart=requires_restart,
+        mtime=mtime,
+    )
 
 
 router = Router(
     path="/config",
-    route_handlers=[get_configuration, update_configuration, get_openapi_schema],
+    route_handlers=[
+        get_configuration,
+        update_configuration,
+        update_configuration_structured,
+    ],
 )

--- a/src/anibridge/app/web/services/configuration_service.py
+++ b/src/anibridge/app/web/services/configuration_service.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, SecretStr
 
 from anibridge.app.config.settings import (
     AnibridgeConfig,
+    _ConfigDumper,
     find_yaml_config_file,
     get_config,
 )
@@ -40,6 +41,8 @@ class ConfigDocumentPayload(TypedDict):
     file_exists: bool
     content: str
     mtime: int | None
+    settings: dict[str, object] | None
+    settings_error: str | None
 
 
 def _normalize_value(value: object) -> object:
@@ -98,16 +101,43 @@ class ConfigurationService:
         except Exception as exc:
             raise ValueError(f"Unable to parse configuration: {exc}") from exc
 
+    def _build_settings_snapshot(
+        self, content: str
+    ) -> tuple[dict[str, object] | None, str | None]:
+        """Parse the config YAML with error logging."""
+        if not content.strip():
+            return {}, None
+        try:
+            payload = self._parse_yaml(content)
+            return dict(payload), None
+        except ValueError as exc:
+            return None, str(exc)
+
+    def _render_settings_payload(self, settings: Mapping[str, object]) -> str:
+        """Render structured settings back into YAML format."""
+        content = yaml.dump(
+            dict(settings),
+            Dumper=_ConfigDumper,
+            sort_keys=False,
+            allow_unicode=False,
+            default_flow_style=False,
+        )
+        return content if content.endswith("\n") else f"{content}\n"
+
     def load_document_text(self) -> ConfigDocumentPayload:
         """Return the raw YAML content alongside file metadata."""
         file_exists = self._config_path.exists()
+        content = (
+            "" if not file_exists else self._config_path.read_text(encoding="utf-8")
+        )
+        settings, settings_error = self._build_settings_snapshot(content)
         return {
             "config_path": str(self._config_path),
             "file_exists": file_exists,
-            "content": ""
-            if not file_exists
-            else self._config_path.read_text(encoding="utf-8"),
+            "content": content,
             "mtime": self._get_mtime_ms(),
+            "settings": settings,
+            "settings_error": settings_error,
         }
 
     async def _apply_runtime_config(self, next_config: AnibridgeConfig) -> bool:
@@ -199,6 +229,35 @@ class ConfigurationService:
             self._config_path.parent.mkdir(parents=True, exist_ok=True)
             normalized_content = content if content.endswith("\n") else f"{content}\n"
             self._config_path.write_text(normalized_content, encoding="utf-8")
+            log.info(
+                f"Configuration updated with {len(config.profiles)} profile(s) at "
+                f"{self._config_path}",
+            )
+
+            requires_restart = await self._apply_runtime_config(config)
+            return config, requires_restart, self._get_mtime_ms()
+
+    async def save_settings_payload(
+        self,
+        settings: Mapping[str, object],
+        *,
+        expected_mtime: int | None = None,
+    ) -> tuple[AnibridgeConfig, bool, int | None]:
+        """Persist structured settings by rewriting the YAML document."""
+        async with self._lock:
+            if expected_mtime is not None:
+                current_mtime = self._get_mtime_ms()
+                if current_mtime is not None and current_mtime != expected_mtime:
+                    raise FileExistsError(
+                        "Configuration file modified on disk; reload to continue."
+                    )
+
+            payload = {str(key): value for key, value in settings.items()}
+            config = self._build_config_instance(payload)
+            rendered = self._render_settings_payload(payload)
+
+            self._config_path.parent.mkdir(parents=True, exist_ok=True)
+            self._config_path.write_text(rendered, encoding="utf-8")
             log.info(
                 f"Configuration updated with {len(config.profiles)} profile(s) at "
                 f"{self._config_path}",

--- a/tests/web/routes/api/test_config.py
+++ b/tests/web/routes/api/test_config.py
@@ -34,7 +34,7 @@ def test_config_api_access_policy(
     )
 
     response = api_client_factory(config_api_module.router, "/api/config").get(
-        "/api/config/openapi.json"
+        "/api/config"
     )
 
     assert response.status_code == expected_status
@@ -90,6 +90,8 @@ def test_get_configuration_success_and_error_translation(
                     "config_path": "/tmp/config.yaml",
                     "file_exists": True,
                     "content": "profiles: {}",
+                    "settings": {"profiles": {}},
+                    "settings_error": None,
                     "mtime": 123,
                 }
             },
@@ -98,6 +100,7 @@ def test_get_configuration_success_and_error_translation(
 
     response = get_configuration()
     assert response.file_exists is True
+    assert response.settings == {"profiles": {}}
     assert "title" in response.schema
 
     monkeypatch.setattr(
@@ -182,4 +185,59 @@ async def test_update_configuration_success_and_error_translation(
         )
         with pytest.raises(HTTPException) as excinfo:
             await config_api_module.update_configuration.fn(request)
+        assert excinfo.value.status_code == status_code
+
+
+@pytest.mark.asyncio
+async def test_update_configuration_structured_success_and_error_translation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = config_api_module.ConfigStructuredUpdateRequest(
+        settings={"profiles": {}}, expected_mtime=123
+    )
+
+    class _Service:
+        async def save_settings_payload(
+            self,
+            settings: dict[str, object],
+            expected_mtime: int | None,
+        ):
+            assert settings == {"profiles": {}}
+            assert expected_mtime == 123
+            return (
+                type("Cfg", (), {"profiles": {"b": object(), "a": object()}})(),
+                True,
+                456,
+            )
+
+    monkeypatch.setattr(
+        config_api_module, "get_configuration_service", lambda: _Service()
+    )
+    response = await config_api_module.update_configuration_structured.fn(request)
+    assert response.profiles == ["a", "b"]
+    assert response.requires_restart is True
+    assert response.mtime == 456
+
+    for exc, status_code in [
+        (FileExistsError("stale"), 409),
+        (ValueError("bad"), 400),
+        (_validation_error(), 422),
+        (SchedulerUnavailableError("busy"), 503),
+    ]:
+
+        class _ErrorService:
+            async def save_settings_payload(
+                self,
+                settings: dict[str, object],
+                expected_mtime: int | None,
+                *,
+                error=exc,
+            ):
+                raise error
+
+        monkeypatch.setattr(
+            config_api_module, "get_configuration_service", lambda: _ErrorService()
+        )
+        with pytest.raises(HTTPException) as excinfo:
+            await config_api_module.update_configuration_structured.fn(request)
         assert excinfo.value.status_code == status_code

--- a/tests/web/services/test_configuration_service.py
+++ b/tests/web/services/test_configuration_service.py
@@ -69,7 +69,22 @@ def test_load_document_text_reports_missing_file(tmp_path: Path):
     assert payload["config_path"] == str(config_path)
     assert payload["file_exists"] is False
     assert payload["content"] == ""
+    assert payload["settings"] == {}
+    assert payload["settings_error"] is None
     assert payload["mtime"] is None
+
+
+def test_load_document_text_reports_structured_parse_errors(tmp_path: Path):
+    """Broken YAML should still load raw text while surfacing a UI parse error."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("profiles:\n  default: [\n", encoding="utf-8")
+    service = ConfigurationService(config_path=config_path)
+
+    payload = service.load_document_text()
+
+    assert payload["content"] == "profiles:\n  default: [\n"
+    assert payload["settings"] is None
+    assert payload["settings_error"] is not None
 
 
 @pytest.mark.asyncio
@@ -172,6 +187,55 @@ async def test_save_document_text_applies_live_profile_and_mapping_updates(
         scheduler.shared_animap_client.mappings_client.upstream_url
         == "https://example.com/mappings-b.json"
     )
+
+
+@pytest.mark.asyncio
+async def test_save_settings_payload_rewrites_yaml_and_discards_comments(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Structured saves should rewrite the YAML document without preserving comments."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "# top comment\n"
+        "mappings_url: https://example.com/mappings-a.json # keep me\n"
+        "profiles:\n"
+        "    default: # profile comment\n"
+        "        library_provider: mocklib # lib comment\n"
+        "        list_provider: mocklist\n",
+        encoding="utf-8",
+    )
+    service = ConfigurationService(config_path=config_path)
+    runtime_config = _runtime_config(config_path.read_text(encoding="utf-8"))
+
+    monkeypatch.setattr(
+        configuration_service_module, "get_config", lambda: runtime_config
+    )
+    monkeypatch.setattr(
+        configuration_service_module,
+        "get_app_state",
+        lambda: type("State", (), {"scheduler": None})(),
+    )
+
+    _, requires_restart, _ = await service.save_settings_payload(
+        {
+            "mappings_url": "https://example.com/mappings-b.json",
+            "profiles": {
+                "default": {
+                    "library_provider": "mocklib",
+                    "list_provider": "mocklist",
+                    "scan_interval": 120,
+                }
+            },
+        }
+    )
+
+    saved = config_path.read_text(encoding="utf-8")
+    assert requires_restart is False
+    assert "# top comment" not in saved
+    assert "# keep me" not in saved
+    assert "# profile comment" not in saved
+    assert "# lib comment" not in saved
+    assert "scan_interval: 120" in saved
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Description

This PR introduces a UI-based config editor to support the already existing YAML editor.

The implementation utilizes a generic JSON schema form generator, so changes to the AniBridge configuration schema should automatically reflect in the config editor.

<img width="2880" height="1800" alt="Screen Shot 2026-05-10 at 02 38 41" src="https://github.com/user-attachments/assets/48b9376d-00b3-4fd3-8da8-99f35539a739" />

**What's new:**

- Guided UI config editor tab
- Configuration API updated to return structured JSON config in addition to raw YAML

### Issues Fixed or Closed by this PR

- Closes #247 

### Checklist

- [x] I have performed a self-review of my own code
- [x] My code passes the test suite (`pytest`)
- [x] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
