### PR TITLE
Mappings includes web config

### DIFF
--- a/frontend/src/lib/components/mappings/includes-modal.svelte
+++ b/frontend/src/lib/components/mappings/includes-modal.svelte
@@ -1,0 +1,258 @@
+<script lang="ts">
+    import { Lock, Plus, RefreshCcw, Save, Trash2 } from "@lucide/svelte";
+
+    import type { MappingConfig, MappingConfigPayload } from "$lib/types/api";
+    import Modal from "$lib/ui/modal.svelte";
+    import { apiFetch } from "$lib/utils/api";
+
+    interface Props {
+        open: boolean;
+        onSaved?: (detail: MappingConfig) => void;
+    }
+
+    type IncludeRow = { id: string; value: string };
+
+    let { open = $bindable(false), onSaved }: Props = $props();
+
+    let rows = $state<IncludeRow[]>([]);
+    let mappingsUrl = $state("");
+    let configPath = $state("");
+    let configFormat = $state("");
+    let loading = $state(false);
+    let saving = $state(false);
+    let error = $state<string | null>(null);
+
+    function makeKey(): string {
+        return `include-${Math.random().toString(36).slice(2)}`;
+    }
+
+    function emptyRow(): IncludeRow {
+        return { id: makeKey(), value: "" };
+    }
+
+    function hydrate(config: MappingConfig) {
+        rows = config.includes.map((value) => ({ id: makeKey(), value }));
+        mappingsUrl = config.mappings_url;
+        configPath = config.path;
+        configFormat = config.format;
+    }
+
+    function resetState() {
+        rows = [];
+        mappingsUrl = "";
+        configPath = "";
+        configFormat = "";
+        loading = false;
+        saving = false;
+        error = null;
+    }
+
+    function addRow() {
+        rows = [...rows, emptyRow()];
+    }
+
+    function removeRow(id: string) {
+        rows = rows.filter((row) => row.id !== id);
+    }
+
+    function updateRow(id: string, value: string) {
+        rows = rows.map((row) => (row.id === id ? { ...row, value } : row));
+    }
+
+    function buildPayload(): MappingConfigPayload {
+        return { includes: rows.map((row) => row.value.trim()).filter(Boolean) };
+    }
+
+    async function loadConfig() {
+        loading = true;
+        error = null;
+        try {
+            const res = await apiFetch("/api/mappings/config", undefined, {
+                silent: true,
+            });
+            if (!res.ok) {
+                throw new Error(`HTTP ${res.status}`);
+            }
+            hydrate(
+                ((await res.json()) as MappingConfig) || {
+                    mappings_url: "",
+                    includes: [],
+                    path: "",
+                    format: "",
+                },
+            );
+        } catch (err) {
+            console.error("Failed to load mappings includes", err);
+            error = "Failed to load includes";
+            rows = [];
+        } finally {
+            loading = false;
+        }
+    }
+
+    async function handleSave() {
+        saving = true;
+        error = null;
+        try {
+            const payload = buildPayload();
+            const res = await apiFetch(
+                "/api/mappings/config",
+                {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(payload),
+                },
+                { successMessage: "Mappings includes updated" },
+            );
+            if (!res.ok) {
+                throw new Error(`HTTP ${res.status}`);
+            }
+            const data = (await res.json()) as MappingConfig;
+            hydrate(data);
+            onSaved?.(data);
+            open = false;
+        } catch (err) {
+            console.error("Failed to save mappings includes", err);
+            error = "Failed to save includes";
+        } finally {
+            saving = false;
+        }
+    }
+
+    $effect(() => {
+        if (!open) {
+            resetState();
+            return;
+        }
+
+        loadConfig();
+    });
+</script>
+
+<Modal
+    bind:open
+    contentClass="fixed top-1/2 left-1/2 z-50 w-full max-w-6xl max-h-[90vh] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-slate-800 bg-slate-950/90 shadow-2xl ring-1 ring-slate-800/60 backdrop-blur flex flex-col overflow-hidden"
+    bodyClass="space-y-4 p-4 overflow-y-auto flex-1 min-w-0"
+    headerWrapperClass="border-b border-slate-800/80 bg-slate-900/70 px-4 py-3 flex-shrink-0"
+    footerClass="flex items-center justify-end gap-3 border-t border-slate-800/70 bg-slate-900/70 px-4 py-3 flex-shrink-0"
+    closeButtonClass="rounded-md px-2 py-1 text-xs text-slate-400 hover:bg-slate-800/70 hover:text-slate-100">
+    {#snippet titleChildren()}
+        <div class="text-sm font-semibold tracking-wide text-slate-100">
+            Mappings Includes
+        </div>
+    {/snippet}
+
+    <div
+        class="flex flex-wrap items-center justify-between gap-3 text-[11px] text-slate-400">
+        <div class="space-y-1">
+            {#if configPath}
+                <div>
+                    Editing <span class="font-mono text-slate-300">{configPath}</span>
+                    {#if configFormat}
+                        <span class="text-slate-500">({configFormat})</span>
+                    {/if}
+                </div>
+            {/if}
+            <p>
+                These are the additional mapping sources included with the main mappings
+                file.
+            </p>
+            <p>The first source is the configured mappings URL and cannot be edited.</p>
+        </div>
+        <div class="flex flex-wrap items-center gap-2 text-[11px]">
+            <button
+                type="button"
+                class="inline-flex items-center gap-1 rounded-md border border-slate-700/60 bg-slate-800/60 px-3 py-2 text-xs font-semibold text-slate-100 shadow-sm transition-colors hover:border-emerald-500 hover:text-emerald-100 focus:ring-2 focus:ring-emerald-500/40 focus:outline-none"
+                onclick={addRow}
+                disabled={loading || saving}>
+                <Plus class="inline h-3.5 w-3.5" />
+                Add Include
+            </button>
+        </div>
+    </div>
+
+    {#if loading}
+        <div
+            class="rounded-md border border-dashed border-slate-800 bg-slate-950/70 p-6 text-center text-sm text-slate-400">
+            Loading includes...
+        </div>
+    {:else}
+        <div class="space-y-4">
+            <div
+                class="rounded-md border border-slate-800 bg-slate-950/80 p-4 shadow-md">
+                <div class="flex items-center gap-2">
+                    <input
+                        class="h-9 w-full rounded-md border border-slate-800/70 bg-slate-900 px-3 text-[13px] text-slate-400 placeholder:text-slate-500 placeholder:opacity-70 focus:outline-none disabled:cursor-not-allowed disabled:opacity-80"
+                        value={mappingsUrl}
+                        aria-label="Mappings URL"
+                        disabled />
+                    <div
+                        class="inline-flex items-center rounded-md border border-slate-700/60 bg-slate-900/60 p-1 text-[12px] font-semibold text-slate-400"
+                        title="Locked mappings URL"
+                        aria-label="Locked mappings URL">
+                        <Lock class="h-4 w-4" />
+                    </div>
+                </div>
+            </div>
+
+            {#if rows.length === 0}
+                <div
+                    class="rounded-md border border-dashed border-slate-800 bg-slate-950/70 p-6 text-center text-sm text-slate-400">
+                    No includes configured.
+                </div>
+            {:else}
+                {#each rows as row, index (row.id)}
+                    <div
+                        class="rounded-md border border-slate-800 bg-slate-950/80 p-4 shadow-md">
+                        <div class="flex items-center gap-2">
+                            <input
+                                class="h-9 w-full rounded-md border border-slate-800/70 bg-slate-900 px-3 text-[13px] text-slate-100 placeholder:text-slate-500 placeholder:opacity-70 focus:border-emerald-500 focus:outline-none"
+                                placeholder="/example/path/to/mappings.json or https://example.com/mappings.json"
+                                value={row.value}
+                                aria-label={`Include ${index + 2}`}
+                                oninput={(event) =>
+                                    updateRow(
+                                        row.id,
+                                        (event.currentTarget as HTMLInputElement).value,
+                                    )} />
+                            <button
+                                type="button"
+                                class="inline-flex items-center rounded-md border border-slate-700/60 bg-slate-900/60 p-1 text-[12px] font-semibold text-rose-200 transition-colors hover:border-rose-500 focus:outline-none disabled:pointer-events-none disabled:opacity-50 disabled:hover:border-slate-700/60 disabled:hover:text-rose-200"
+                                title="Remove include"
+                                onclick={() => removeRow(row.id)}
+                                disabled={saving}>
+                                <Trash2 class="inline h-4 w-4" />
+                            </button>
+                        </div>
+                    </div>
+                {/each}
+            {/if}
+        </div>
+    {/if}
+
+    {#if error}
+        <div
+            class="rounded-md border border-rose-800 bg-rose-900/40 p-3 text-[12px] text-rose-100">
+            {error}
+        </div>
+    {/if}
+
+    {#snippet footerChildren()}
+        <button
+            type="button"
+            class="inline-flex items-center gap-2 rounded-md border border-slate-700/60 bg-slate-800/60 px-3 py-2 text-[12px] font-semibold text-slate-100 shadow-sm transition-colors hover:border-slate-500 focus:ring-2 focus:ring-slate-500/40 focus:outline-none"
+            onclick={loadConfig}
+            disabled={loading || saving}>
+            <RefreshCcw class={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+            Reload
+        </button>
+        <button
+            type="button"
+            class="inline-flex items-center gap-2 rounded-md border border-emerald-600/60 bg-emerald-600/30 px-3 py-2 text-[12px] font-semibold text-emerald-100 shadow-sm transition-colors hover:bg-emerald-600/40 focus:ring-2 focus:ring-emerald-500/40 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            onclick={handleSave}
+            disabled={loading || saving}>
+            <Save class={`h-4 w-4 ${saving ? "animate-spin" : ""}`} />
+            Save
+        </button>
+    {/snippet}
+</Modal>

--- a/frontend/src/lib/components/mappings/tool-bar.svelte
+++ b/frontend/src/lib/components/mappings/tool-bar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Check, Plus } from "@lucide/svelte";
+    import { Check, FolderTree, Plus } from "@lucide/svelte";
     import { twMerge } from "tailwind-merge";
 
     import BooruSearch from "$lib/components/mappings/booru-search.svelte";
@@ -14,6 +14,7 @@
         onCancel: () => void;
         onSubmit?: () => void;
         onCreate?: () => void;
+        onIncludes?: () => void;
     }
 
     let {
@@ -25,6 +26,7 @@
         onLoad,
         onCancel,
         onCreate,
+        onIncludes,
         onSubmit,
     }: Props = $props();
 
@@ -80,6 +82,14 @@
         {/if}
         <span>Custom Only</span>
     </button>
+    <button
+        title="Manage Includes"
+        aria-label="Manage Includes"
+        onclick={() => onIncludes?.()}
+        class="inline-flex h-8 items-center gap-1 rounded-md bg-slate-800 px-3 text-[11px] font-medium text-slate-300 ring-1 ring-slate-700/60 transition-colors hover:bg-slate-700">
+        <FolderTree class="inline h-3.5 w-3.5 text-[14px]" />
+        <span>Includes</span>
+    </button>
     <div class="ml-auto flex items-center gap-2">
         <button
             title="New Override"
@@ -110,31 +120,41 @@
             }} />
     </div>
     <div class="flex flex-wrap items-center justify-between">
-        <button
-            onclick={toggleCustom}
-            class={`inline-flex h-8 items-center gap-1 rounded-md px-3 text-[11px] font-medium ring-1 ${customOnly ? "bg-emerald-600/90 text-white ring-emerald-500/40 hover:bg-emerald-500" : "bg-slate-800 text-slate-300 ring-slate-700/60 hover:bg-slate-700"}`}>
-            {#if customOnly}
-                <Check class="inline h-3.5 w-3.5" />
-            {:else}
-                <svg
-                    class="inline h-3.5 w-3.5"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    ><rect
-                        x="3"
-                        y="3"
-                        width="18"
-                        height="18"
-                        rx="2"
-                        ry="2"></rect
-                    ></svg>
-            {/if}
-            <span>Custom Only</span>
-        </button>
+        <div class="flex flex-wrap items-center gap-2">
+            <button
+                title="Manage Includes"
+                aria-label="Manage Includes"
+                onclick={() => onIncludes?.()}
+                class="inline-flex h-8 items-center gap-1 rounded-md bg-slate-800 px-3 text-[11px] font-medium text-slate-300 ring-1 ring-slate-700/60 transition-colors hover:bg-slate-700">
+                <FolderTree class="inline h-3.5 w-3.5" />
+                <span>Includes</span>
+            </button>
+            <button
+                onclick={toggleCustom}
+                class={`inline-flex h-8 items-center gap-1 rounded-md px-3 text-[11px] font-medium ring-1 ${customOnly ? "bg-emerald-600/90 text-white ring-emerald-500/40 hover:bg-emerald-500" : "bg-slate-800 text-slate-300 ring-slate-700/60 hover:bg-slate-700"}`}>
+                {#if customOnly}
+                    <Check class="inline h-3.5 w-3.5" />
+                {:else}
+                    <svg
+                        class="inline h-3.5 w-3.5"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        ><rect
+                            x="3"
+                            y="3"
+                            width="18"
+                            height="18"
+                            rx="2"
+                            ry="2"></rect
+                        ></svg>
+                {/if}
+                <span>Custom Only</span>
+            </button>
+        </div>
         <button
             title="New Override"
             aria-label="New Override"

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -55,6 +55,10 @@ export interface MappingOverridePayload {
     targets: TargetPayload[];
 }
 
+export interface MappingConfigPayload {
+    includes: string[];
+}
+
 export type RangeOrigin = "upstream" | "custom";
 export type TargetOrigin = "upstream" | "custom" | "mixed";
 
@@ -90,6 +94,13 @@ export interface MappingDetail {
     scope: string | null;
     layers: MappingLayers;
     targets: MappingTarget[];
+}
+
+export interface MappingConfig {
+    mappings_url: string;
+    includes: string[];
+    path: string;
+    format: string;
 }
 
 export interface ListMappingsResponse {

--- a/frontend/src/routes/mappings/+page.svelte
+++ b/frontend/src/routes/mappings/+page.svelte
@@ -15,10 +15,11 @@
         type ColumnConfig,
     } from "$lib/components/mappings/columns";
     import EditModal from "$lib/components/mappings/edit-modal.svelte";
+    import IncludesModal from "$lib/components/mappings/includes-modal.svelte";
     import MappingsTable from "$lib/components/mappings/mappings-table.svelte";
     import SearchBar from "$lib/components/mappings/tool-bar.svelte";
     import Pagination from "$lib/components/pagination.svelte";
-    import type { Mapping } from "$lib/types/api";
+    import type { Mapping, MappingConfig } from "$lib/types/api";
     import { apiFetch, isAbortError } from "$lib/utils/api";
     import { toast } from "$lib/utils/notify";
 
@@ -36,6 +37,7 @@
     let editorOpen = $state(false);
     let editorMode = $state<"create" | "edit">("create");
     let editorTarget = $state<Mapping | null>(null);
+    let includesOpen = $state(false);
 
     let pendingReplaceState: boolean | null = null;
     let searchBarKey = $state(0);
@@ -130,6 +132,10 @@
         editorOpen = true;
     }
 
+    function openIncludesEditor() {
+        includesOpen = true;
+    }
+
     function handleEdit({ mapping }: { mapping: Mapping }) {
         editorMode = "edit";
         editorTarget = mapping;
@@ -138,6 +144,13 @@
 
     async function handleSaved() {
         editorOpen = false;
+        clearCapabilitiesCache();
+        searchBarKey += 1;
+        await load();
+    }
+
+    async function handleIncludesSaved(_config: MappingConfig) {
+        includesOpen = false;
         clearCapabilitiesCache();
         searchBarKey += 1;
         await load();
@@ -255,6 +268,7 @@
                 onLoad={load}
                 onCancel={cancelLoad}
                 onCreate={openCreateEditor}
+                onIncludes={openIncludesEditor}
                 onSubmit={handleSearchSubmit} />
         {/key}
     </div>
@@ -358,3 +372,7 @@
     mode={editorMode}
     mapping={editorTarget}
     onSaved={handleSaved} />
+
+<IncludesModal
+    bind:open={includesOpen}
+    onSaved={handleIncludesSaved} />

--- a/frontend/src/routes/mappings/+page.svelte
+++ b/frontend/src/routes/mappings/+page.svelte
@@ -19,7 +19,7 @@
     import MappingsTable from "$lib/components/mappings/mappings-table.svelte";
     import SearchBar from "$lib/components/mappings/tool-bar.svelte";
     import Pagination from "$lib/components/pagination.svelte";
-    import type { Mapping, MappingConfig } from "$lib/types/api";
+    import type { Mapping } from "$lib/types/api";
     import { apiFetch, isAbortError } from "$lib/utils/api";
     import { toast } from "$lib/utils/notify";
 
@@ -149,7 +149,7 @@
         await load();
     }
 
-    async function handleIncludesSaved(_config: MappingConfig) {
+    async function handleIncludesSaved() {
         includesOpen = false;
         clearCapabilitiesCache();
         searchBarKey += 1;

--- a/src/anibridge/app/web/routes/api/mappings.py
+++ b/src/anibridge/app/web/routes/api/mappings.py
@@ -326,6 +326,55 @@ class MappingOverridePayload(msgspec.Struct):
     ] = msgspec.field(default_factory=list)
 
 
+class MappingConfigPayload(msgspec.Struct):
+    """Payload for updating top-level mappings configuration."""
+
+    includes: Annotated[
+        list[str],
+        msgspec.Meta(
+            description="Top-level mapping sources loaded via the $includes field.",
+            examples=[
+                ["/example/path/to/mappings.json", "https://example.com/mappings.json"]
+            ],
+        ),
+    ] = msgspec.field(default_factory=list)
+
+
+class MappingConfigModel(msgspec.Struct):
+    """Editable top-level mappings configuration."""
+
+    path: Annotated[
+        str,
+        msgspec.Meta(
+            min_length=1,
+            description="Filesystem path of the custom mappings file being edited.",
+            examples=["/data/mappings.json"],
+        ),
+    ]
+    format: Annotated[
+        str,
+        msgspec.Meta(
+            min_length=1,
+            description="Serialization format of the custom mappings file.",
+            examples=["json"],
+        ),
+    ]
+    includes: Annotated[
+        list[str],
+        msgspec.Meta(
+            description="Resolved include entries from the custom mappings file.",
+            examples=[["./mappings.yaml", "https://example.com/mappings.json"]],
+        ),
+    ] = msgspec.field(default_factory=list)
+    mappings_url: Annotated[
+        str,
+        msgspec.Meta(
+            description="Upstream mappings source configured for the app.",
+            examples=["https://example.com/mappings.json"],
+        ),
+    ] = ""
+
+
 class MappingRangeViewModel(msgspec.Struct):
     source_range: Annotated[
         str,
@@ -673,6 +722,13 @@ async def get_mapping(descriptor: str) -> MappingDetailModel:
     return msgspec.convert(data, type=MappingDetailModel)
 
 
+@get(path="/config")
+async def get_mapping_config() -> MappingConfigModel:
+    svc = get_mapping_overrides_service()
+    data = await svc.get_mapping_config()
+    return msgspec.convert(data, type=MappingConfigModel)
+
+
 @post(path="", status_code=200)
 async def create_mapping(
     data: Annotated[MappingOverridePayload, Body()],
@@ -701,13 +757,24 @@ async def update_mapping(
     return msgspec.convert(saved, type=MappingDetailModel)
 
 
+@put(path="/config")
+async def update_mapping_config(
+    data: Annotated[MappingConfigPayload, Body()],
+) -> MappingConfigModel:
+    svc = get_mapping_overrides_service()
+    saved = await svc.save_mapping_config(includes=list(data.includes))
+    return msgspec.convert(saved, type=MappingConfigModel)
+
+
 router = Router(
     path="/mappings",
     route_handlers=[
         list_mappings,
         query_capabilities,
+        get_mapping_config,
         get_mapping,
         create_mapping,
         update_mapping,
+        update_mapping_config,
     ],
 )

--- a/src/anibridge/app/web/services/mapping_overrides_service.py
+++ b/src/anibridge/app/web/services/mapping_overrides_service.py
@@ -141,6 +141,20 @@ class MappingOverridesService:
             cleaned[target_str] = normalized_ranges
         return cleaned
 
+    def _normalize_includes(self, raw: Any) -> list[str]:
+        """Normalize the top-level include list from the raw mappings payload."""
+        if not isinstance(raw, list):
+            return []
+
+        includes: list[str] = []
+        for item in raw:
+            if item is None:
+                continue
+            value = str(item).strip()
+            if value:
+                includes.append(value)
+        return includes
+
     def _merge_targets(
         self,
         upstream: dict[str, dict[str, str | None] | None],
@@ -304,6 +318,18 @@ class MappingOverridesService:
             ),
         }
 
+    async def get_mapping_config(self) -> dict[str, Any]:
+        """Return top-level mappings configuration editable from the web UI."""
+        async with self._lock:
+            raw, path, fmt = self._load_raw()
+
+        return {
+            "mappings_url": self._config.mappings_url or "",
+            "includes": self._normalize_includes(raw.get("$includes")),
+            "path": str(path),
+            "format": fmt,
+        }
+
     def _validate_ranges(
         self, ranges: list[dict[str, Any]] | None
     ) -> dict[str, str | None]:
@@ -397,6 +423,23 @@ class MappingOverridesService:
 
         await self._sync_database()
         return await self.get_mapping_detail(descriptor_str)
+
+    async def save_mapping_config(
+        self, *, includes: list[str] | None
+    ) -> dict[str, Any]:
+        """Persist top-level mappings configuration and trigger DB sync."""
+        normalized_includes = self._normalize_includes(includes or [])
+
+        async with self._lock:
+            raw, path, fmt = self._load_raw()
+            if normalized_includes:
+                raw["$includes"] = normalized_includes
+            else:
+                raw.pop("$includes", None)
+            self._write_raw(raw, path, fmt)
+
+        await self._sync_database()
+        return await self.get_mapping_config()
 
 
 @cache

--- a/tests/web/routes/api/test_mappings.py
+++ b/tests/web/routes/api/test_mappings.py
@@ -108,6 +108,14 @@ def test_list_mappings_and_override_routes(monkeypatch: pytest.MonkeyPatch) -> N
             )
 
     class _OverridesService:
+        async def get_mapping_config(self):
+            return {
+                "mappings_url": "https://example.com/mappings.json",
+                "includes": ["./community.yaml"],
+                "path": "/tmp/mappings.json",
+                "format": "json",
+            }
+
         async def get_mapping_detail(self, descriptor: str):
             return {
                 "descriptor": descriptor,
@@ -126,6 +134,14 @@ def test_list_mappings_and_override_routes(monkeypatch: pytest.MonkeyPatch) -> N
                 "scope": None,
                 "layers": {},
                 "targets": [],
+            }
+
+        async def save_mapping_config(self, **kwargs):
+            return {
+                "mappings_url": "https://example.com/mappings.json",
+                "includes": kwargs["includes"],
+                "path": "/tmp/mappings.json",
+                "format": "json",
             }
 
     monkeypatch.setattr(
@@ -153,6 +169,11 @@ def test_list_mappings_and_override_routes(monkeypatch: pytest.MonkeyPatch) -> N
     assert listed.status_code == 200
     assert listed.json()["pages"] == 3
 
+    config = client.get("/api/mappings/config")
+    assert config.status_code == 200
+    assert config.json()["mappings_url"] == "https://example.com/mappings.json"
+    assert config.json()["includes"] == ["./community.yaml"]
+
     detail = client.get("/api/mappings/anilist:1")
     assert detail.status_code == 200
 
@@ -161,6 +182,16 @@ def test_list_mappings_and_override_routes(monkeypatch: pytest.MonkeyPatch) -> N
         json={"descriptor": "anilist:1", "targets": []},
     )
     assert created.status_code == 200
+
+    updated_config = client.put(
+        "/api/mappings/config",
+        json={"includes": ["./community.yaml", "https://example.com/base.json"]},
+    )
+    assert updated_config.status_code == 200
+    assert updated_config.json()["includes"] == [
+        "./community.yaml",
+        "https://example.com/base.json",
+    ]
 
     updated = asyncio.run(
         update_mapping(

--- a/tests/web/services/test_mapping_overrides_service.py
+++ b/tests/web/services/test_mapping_overrides_service.py
@@ -278,6 +278,11 @@ def test_mapping_overrides_service_normalizes_and_builds_views() -> None:
     assert len(views) == 2
     assert views[0]["origin"] in {"mixed", "deleted"}
     assert {view["descriptor"] for view in views} == {"tmdb:1", "tvdb:2"}
+    assert service._normalize_includes([" ./a.yaml ", "", 123, None]) == [
+        "./a.yaml",
+        "123",
+    ]
+    assert service._normalize_includes("bad") == []
 
 
 def test_mapping_overrides_service_validation_errors() -> None:
@@ -317,3 +322,69 @@ async def test_save_override_requires_descriptor_and_removes_entry(
     assert result["layers"]["custom"] == {}
     raw = json.loads((tmp_path / "mappings.json").read_text(encoding="utf-8"))
     assert raw == {}
+
+
+@pytest.mark.asyncio
+async def test_mapping_config_round_trips_includes_and_preserves_overrides(
+    overrides_env: tuple[Path, DummyScheduler],
+) -> None:
+    """Saving mapping config should only touch the top-level include list."""
+    tmp_path, scheduler = overrides_env
+    (tmp_path / "mappings.json").write_text(
+        json.dumps(
+            {
+                "$includes": ["./old.yaml"],
+                "anilist:123": {"tmdb:456": {"1": "1"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    service = MappingOverridesService()
+
+    loaded = await service.get_mapping_config()
+    assert loaded["mappings_url"] == get_config().mappings_url
+    assert loaded["includes"] == ["./old.yaml"]
+    assert loaded["format"] == "json"
+
+    saved = await service.save_mapping_config(
+        includes=[" ./community.yaml ", "https://example.com/base.json", ""]
+    )
+
+    assert saved["includes"] == [
+        "./community.yaml",
+        "https://example.com/base.json",
+    ]
+    assert saved["mappings_url"] == get_config().mappings_url
+    assert scheduler.sync_sources == ["service:mapping_overrides"]
+
+    raw = json.loads((tmp_path / "mappings.json").read_text(encoding="utf-8"))
+    assert raw == {
+        "$includes": ["./community.yaml", "https://example.com/base.json"],
+        "anilist:123": {"tmdb:456": {"1": "1"}},
+    }
+
+
+@pytest.mark.asyncio
+async def test_mapping_config_removes_empty_includes_key(
+    overrides_env: tuple[Path, DummyScheduler],
+) -> None:
+    """Saving an empty include list should drop the top-level key."""
+    tmp_path, _scheduler = overrides_env
+    (tmp_path / "mappings.json").write_text(
+        json.dumps(
+            {
+                "$includes": ["./old.yaml"],
+                "anilist:123": {"tmdb:456": {"1": "1"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    service = MappingOverridesService()
+    saved = await service.save_mapping_config(includes=[])
+
+    assert saved["mappings_url"] == get_config().mappings_url
+    assert saved["includes"] == []
+    raw = json.loads((tmp_path / "mappings.json").read_text(encoding="utf-8"))
+    assert raw == {"anilist:123": {"tmdb:456": {"1": "1"}}}


### PR DESCRIPTION
### Description

This PR adds an `$includes` management modal in the mappings page.

<img width="2880" height="1800" alt="Screen Shot 2026-05-10 at 03 09 04" src="https://github.com/user-attachments/assets/e6314513-6fbb-4d66-909d-6b29523c7729" />

**What's new:**

- Mappings includes management

### Issues Fixed or Closed by this PR

- Closes #257 

### Checklist

- [x] I have performed a self-review of my own code
- [x] My code passes the test suite (`pytest`)
- [x] My code passes the code style checks of this project (`ruff check && (cd frontend && pnpm lint)`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
